### PR TITLE
Ny knapp for å sende inn søknad med familiepdf endepunktet

### DIFF
--- a/src/innsending/api.ts
+++ b/src/innsending/api.ts
@@ -13,6 +13,21 @@ export const sendInnSøknad = (søknad: object) => {
     });
 };
 
+export const sendInnSøknadFamiliePdf = (søknad: object) => {
+  return axios
+    .post(
+      `${Environment().apiProxyUrl}/api/soknadskvittering/overgangsstonad`,
+      søknad,
+      {
+        headers: { 'Content-Type': 'application/json;charset=utf-8' },
+        withCredentials: true,
+      }
+    )
+    .then((response: { data: any }) => {
+      return response.data;
+    });
+};
+
 export const sendInnBarnetilsynSøknad = (søknad: object) => {
   return axios
     .post(`${Environment().apiProxyUrl}/api/soknadbarnetilsyn`, søknad, {

--- a/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
@@ -18,6 +18,7 @@ import {
   mapBarnTilEntenIdentEllerFødselsdato,
   mapBarnUtenBarnepass,
   sendInnSøknad,
+  sendInnSøknadFamiliePdf,
 } from '../../../innsending/api';
 import { hentForrigeRoute, hentNesteRoute } from '../../../utils/routing';
 import { unikeDokumentasjonsbehov } from '../../../utils/søknad';
@@ -56,7 +57,7 @@ const SendSøknadKnapper: FC = () => {
     venter: false,
   });
 
-  const sendSøknad = (søknad: ISøknad) => {
+  const sendSøknad = (søknad: ISøknad, brukFamiliePdf?: boolean) => {
     const barnMedEntenIdentEllerFødselsdato = mapBarnUtenBarnepass(
       mapBarnTilEntenIdentEllerFødselsdato(søknad.person.barn)
     );
@@ -79,7 +80,10 @@ const SendSøknadKnapper: FC = () => {
     const skjemaId = skjemanavnIdMapping[ESkjemanavn.Overgangsstønad];
 
     settinnsendingState({ ...innsendingState, venter: true });
-    sendInnSøknad(søknadKlarForSending)
+
+    (brukFamiliePdf ? sendInnSøknadFamiliePdf : sendInnSøknad)(
+      søknadKlarForSending
+    )
       .then((kvittering) => {
         settinnsendingState({
           ...innsendingState,
@@ -161,6 +165,16 @@ const SendSøknadKnapper: FC = () => {
             <LocaleTekst tekst={'knapp.avbryt'} />
           </Button>
         </StyledKnapper>
+        <div style={{ marginLeft: '20px' }}>
+          <Button
+            className={'neste'}
+            variant="secondary"
+            loading={innsendingState.venter}
+            onClick={() => !innsendingState.venter && sendSøknad(søknad, true)}
+          >
+            <LocaleTekst tekst={'Familie pdf - Send søknad '} />
+          </Button>
+        </div>
       </SeksjonGruppe>
     </>
   );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å kunne teste nye flyten med bruk av familie-pdf for generering av pdfer, så er det lagt til en knapp som bruker familie-pdf endepunktet i stedet for det vanlige endepunktet.

Her skal også en featureToggle legges til før det merges inn i prod

**Endringer:**
<img width="724" alt="image" src="https://github.com/user-attachments/assets/a6c4dd78-c92f-4bec-a001-039ab6af3cec">
