### PR TITLE
Kan ikke sende inn to søknader med samme dokumentasjonsbehov og må de…

### DIFF
--- a/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
@@ -69,7 +69,10 @@ const SendSøknadKnapper: FC = () => {
   ) => {
     try {
       if (brukFamiliePdf) {
-        await sendInnSøknadFamiliePdf(søknadMedFiltrerteBarn);
+        await sendInnSøknadFamiliePdf({
+          ...søknadMedFiltrerteBarn,
+          dokumentasjonsbehov: [],
+        });
       }
       const kvittering = await sendInnSøknad(søknadMedFiltrerteBarn);
 

--- a/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
@@ -68,13 +68,16 @@ const SendSøknadKnapper: FC = () => {
     søknadMedFiltrerteBarn: ISøknad
   ) => {
     try {
+      let kvittering;
       if (brukFamiliePdf) {
-        await sendInnSøknadFamiliePdf({
+        await sendInnSøknadFamiliePdf(søknadMedFiltrerteBarn);
+        kvittering = await sendInnSøknad({
           ...søknadMedFiltrerteBarn,
           dokumentasjonsbehov: [],
         });
+      } else {
+        kvittering = await sendInnSøknad(søknadMedFiltrerteBarn);
       }
-      const kvittering = await sendInnSøknad(søknadMedFiltrerteBarn);
 
       settinnsendingState({
         ...innsendingState,

--- a/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
@@ -70,8 +70,8 @@ const SendSøknadKnapper: FC = () => {
     try {
       let kvittering;
       if (brukFamiliePdf) {
-        await sendInnSøknadFamiliePdf(søknadMedFiltrerteBarn);
-        kvittering = await sendInnSøknad({
+        kvittering = await sendInnSøknadFamiliePdf(søknadMedFiltrerteBarn);
+        await sendInnSøknad({
           ...søknadMedFiltrerteBarn,
           dokumentasjonsbehov: [],
         });


### PR DESCRIPTION
…rfor fjerne dokumentasjonsbehovene for søknader med ny pdf-sløyfe

### Hvorfor er denne endringen nødvendig? ✨
Får databasefeil i mottak når man sender inn "samme søknad" to ganger med de samme vedleggene. 