### PR TITLE
Fikse utenlandsopphold tekst

### DIFF
--- a/src/components/EøsIdent.tsx
+++ b/src/components/EøsIdent.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Checkbox, Label, ReadMore } from '@navikt/ds-react';
 import { TextFieldMedBredde } from './TextFieldMedBredde';
-import { hentTekst } from '../utils/søknad';
+import { hentTekstMedVariabel } from '../utils/søknad';
 import { useLokalIntlContext } from '../context/LokalIntlContext';
 import { IUtenlandsopphold } from '../models/steg/omDeg/medlemskap';
-import { hentBeskjedMedNavn } from '../utils/språk';
 
 interface Props {
   halvåpenTekstid: string;
@@ -21,9 +20,10 @@ const EøsIdent: React.FC<Props> = ({
 }) => {
   const intl = useLokalIntlContext();
 
-  const tekstMedLand = hentBeskjedMedNavn(
-    utenlandsopphold.land?.verdi || '',
-    hentTekst('medlemskap.periodeBoddIUtlandet.utenlandskIDNummer', intl)
+  const tekstMedLand = hentTekstMedVariabel(
+    'medlemskap.periodeBoddIUtlandet.utenlandskIDNummer',
+    intl,
+    { 0: utenlandsopphold.land?.verdi || '' }
   );
 
   const settUtenlandskPersonId = (
@@ -76,9 +76,10 @@ const EøsIdent: React.FC<Props> = ({
           toggleHarUtenlandskPersonId(!utenlandsopphold.kanIkkeOppgiPersonident)
         }
       >
-        {hentBeskjedMedNavn(
-          utenlandsopphold.land?.verdi || '',
-          hentTekst('medlemskap.periodeBoddIUtlandet.harIkkeIdNummer', intl)
+        {hentTekstMedVariabel(
+          'medlemskap.periodeBoddIUtlandet.harIkkeIdNummer',
+          intl,
+          { 0: utenlandsopphold.land?.verdi || '' }
         )}
       </Checkbox>
     </div>

--- a/src/components/EøsIdent.tsx
+++ b/src/components/EøsIdent.tsx
@@ -20,7 +20,7 @@ const EøsIdent: React.FC<Props> = ({
 }) => {
   const intl = useLokalIntlContext();
 
-  const tekstMedLand = hentTekstMedVariabel(
+  const utenlandskIDNummerTekst = hentTekstMedVariabel(
     'medlemskap.periodeBoddIUtlandet.utenlandskIDNummer',
     intl,
     { 0: utenlandsopphold.land?.verdi || '' }
@@ -32,7 +32,7 @@ const EøsIdent: React.FC<Props> = ({
     const oppdatertUtenlandsopphold = {
       ...utenlandsopphold,
       personidentEøsLand: {
-        label: tekstMedLand,
+        label: utenlandskIDNummerTekst,
         verdi: e.target.value,
       },
     };
@@ -54,7 +54,7 @@ const EøsIdent: React.FC<Props> = ({
 
   return (
     <div>
-      <Label>{tekstMedLand}</Label>
+      <Label>{utenlandskIDNummerTekst}</Label>
       <ReadMore size={'small'} header={halvåpenTekstid}>
         {åpneTekstid}
       </ReadMore>

--- a/src/components/EøsIdent.tsx
+++ b/src/components/EøsIdent.tsx
@@ -20,10 +20,14 @@ const EøsIdent: React.FC<Props> = ({
 }) => {
   const intl = useLokalIntlContext();
 
+  if (!utenlandsopphold.land) {
+    return null;
+  }
+
   const utenlandskIDNummerTekst = hentTekstMedVariabel(
     'medlemskap.periodeBoddIUtlandet.utenlandskIDNummer',
     intl,
-    { 0: utenlandsopphold.land?.verdi || '' }
+    { 0: utenlandsopphold.land.verdi }
   );
 
   const settUtenlandskPersonId = (
@@ -79,7 +83,7 @@ const EøsIdent: React.FC<Props> = ({
         {hentTekstMedVariabel(
           'medlemskap.periodeBoddIUtlandet.harIkkeIdNummer',
           intl,
-          { 0: utenlandsopphold.land?.verdi || '' }
+          { 0: utenlandsopphold.land.verdi }
         )}
       </Checkbox>
     </div>

--- a/src/components/EøsIdent.tsx
+++ b/src/components/EøsIdent.tsx
@@ -4,6 +4,7 @@ import { TextFieldMedBredde } from './TextFieldMedBredde';
 import { hentTekst } from '../utils/søknad';
 import { useLokalIntlContext } from '../context/LokalIntlContext';
 import { IUtenlandsopphold } from '../models/steg/omDeg/medlemskap';
+import { hentBeskjedMedNavn } from '../utils/språk';
 
 interface Props {
   halvåpenTekstid: string;
@@ -20,16 +21,9 @@ const EøsIdent: React.FC<Props> = ({
 }) => {
   const intl = useLokalIntlContext();
 
-  const hentTekstMedLandverdi = (tekst: string) => {
-    return hentTekst(tekst, intl) + ' ' + utenlandsopphold.land?.verdi;
-  };
-
-  const tekstMedLandVerdi =
-    hentTekstMedLandverdi(
-      'medlemskap.periodeBoddIUtlandet.utenlandskIDNummer'
-    ) + '?';
-  const harIkkeUtenlandsPersonIdTekst = hentTekstMedLandverdi(
-    'medlemskap.periodeBoddIUtlandet.harIkkeIdNummer'
+  const tekstMedLand = hentBeskjedMedNavn(
+    utenlandsopphold.land?.verdi || '',
+    hentTekst('medlemskap.periodeBoddIUtlandet.utenlandskIDNummer', intl)
   );
 
   const settUtenlandskPersonId = (
@@ -38,7 +32,7 @@ const EøsIdent: React.FC<Props> = ({
     const oppdatertUtenlandsopphold = {
       ...utenlandsopphold,
       personidentEøsLand: {
-        label: tekstMedLandVerdi,
+        label: tekstMedLand,
         verdi: e.target.value,
       },
     };
@@ -60,7 +54,7 @@ const EøsIdent: React.FC<Props> = ({
 
   return (
     <div>
-      <Label>{tekstMedLandVerdi}</Label>
+      <Label>{tekstMedLand}</Label>
       <ReadMore size={'small'} header={halvåpenTekstid}>
         {åpneTekstid}
       </ReadMore>
@@ -82,7 +76,10 @@ const EøsIdent: React.FC<Props> = ({
           toggleHarUtenlandskPersonId(!utenlandsopphold.kanIkkeOppgiPersonident)
         }
       >
-        {harIkkeUtenlandsPersonIdTekst}
+        {hentBeskjedMedNavn(
+          utenlandsopphold.land?.verdi || '',
+          hentTekst('medlemskap.periodeBoddIUtlandet.harIkkeIdNummer', intl)
+        )}
       </Checkbox>
     </div>
   );

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -173,14 +173,14 @@ export default {
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',
   'medlemskap.periodeBoddIUtlandet.utenlandskIDNummer':
-    'What is your ID number in [0]?',
+    'What is your ID number in {0}?',
   'medlemskap.periodeBoddIUtlandet.harIkkeIdNummer':
-    'I do not have an ID number in [0]',
+    'I do not have an ID number in {0}',
   'medlemskap.hjelpetekst-åpne.begrunnelse': 'The reason we ask about this',
   'medlemskap.hjelpetekst-innhold.begrunnelse':
     'When you have stayed in another EEA country during the last 5 years, we sometimes need to obtain information from that country. This is because we need information to assess whether you are entitled to benefits.',
   'medlemskap.periodeBoddIUtlandet.sisteAdresse':
-    'What is the last address you lived at in [0]?',
+    'What is the last address you lived at in {0}?',
   'medlemskap.periodeBoddIUtlandet.land': 'In what country were you staying?',
   'medlemskap.periodeBoddIUtlandet.slett': 'Remove period spent abroad',
   'medlemskap.periodeBoddIUtlandet': 'When did you live overseas?',

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -173,14 +173,14 @@ export default {
   'medlemskap.spm.bosatt': 'Have you lived in Norway for the past five years?',
   'medlemskap.periodeBoddIUtlandet.utenlandsopphold': 'Period spent abroad ',
   'medlemskap.periodeBoddIUtlandet.utenlandskIDNummer':
-    'What is your ID number in',
+    'What is your ID number in [0]?',
   'medlemskap.periodeBoddIUtlandet.harIkkeIdNummer':
-    'I do not have an ID number in',
+    'I do not have an ID number in [0]',
   'medlemskap.hjelpetekst-åpne.begrunnelse': 'The reason we ask about this',
   'medlemskap.hjelpetekst-innhold.begrunnelse':
     'When you have stayed in another EEA country during the last 5 years, we sometimes need to obtain information from that country. This is because we need information to assess whether you are entitled to benefits.',
   'medlemskap.periodeBoddIUtlandet.sisteAdresse':
-    'What is the last address you lived at in',
+    'What is the last address you lived at in [0]?',
   'medlemskap.periodeBoddIUtlandet.land': 'In what country were you staying?',
   'medlemskap.periodeBoddIUtlandet.slett': 'Remove period spent abroad',
   'medlemskap.periodeBoddIUtlandet': 'When did you live overseas?',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -170,17 +170,17 @@ export default {
   'medlemskap.periodeBoddIUtlandet.slett': 'Fjern utenlandsperiode',
   'medlemskap.periodeBoddIUtlandet': 'Når oppholdt du deg i utlandet?',
   'medlemskap.periodeBoddIUtlandet.utenlandskIDNummer':
-    'Hva er id-nummeret ditt i [0]?',
+    'Hva er id-nummeret ditt i {0}?',
   'medlemskap.periodeBoddIUtlandet.harIkkeIdNummer':
-    'Jeg har ikke id-nummer i [0]',
+    'Jeg har ikke id-nummer i {0}',
   'medlemskap.hjelpetekst-åpne.begrunnelse': 'Grunnen til at vi spør om dette',
   'medlemskap.hjelpetekst-innhold.begrunnelse':
     'Når du har oppholdt deg i et annet EØS-land i løpet av de siste 5 årene, må vi noen ganger innhente opplysninger fra dette landet. Det er fordi vi trenger opplysninger for å vurdere om du har rett til stønad.',
   'medlemskap.periodeBoddIUtlandet.sisteAdresse':
-    'Hva er den siste adressen du bodde på i [0]?',
+    'Hva er den siste adressen du bodde på i {0}?',
   'medlemskap.periodeBoddIUtlandet.land': 'I hvilket land oppholdt du deg i?',
   'medlemskap.periodeBoddIUtlandet.begrunnelse':
-    'Hvorfor oppholdt du deg i [0]?',
+    'Hvorfor oppholdt du deg i {0}?',
   'medlemskap.periodeBoddIUtlandet.flereutenlandsopphold':
     'Har du hatt flere utenlandsopphold de siste 5 årene?',
   'medlemskap.periodeBoddIUtlandet.knapp': 'Legg til et utenlandsopphold',

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -170,15 +170,17 @@ export default {
   'medlemskap.periodeBoddIUtlandet.slett': 'Fjern utenlandsperiode',
   'medlemskap.periodeBoddIUtlandet': 'Når oppholdt du deg i utlandet?',
   'medlemskap.periodeBoddIUtlandet.utenlandskIDNummer':
-    'Hva er id-nummeret ditt i',
-  'medlemskap.periodeBoddIUtlandet.harIkkeIdNummer': 'Jeg har ikke id-nummer i',
+    'Hva er id-nummeret ditt i [0]?',
+  'medlemskap.periodeBoddIUtlandet.harIkkeIdNummer':
+    'Jeg har ikke id-nummer i [0]',
   'medlemskap.hjelpetekst-åpne.begrunnelse': 'Grunnen til at vi spør om dette',
   'medlemskap.hjelpetekst-innhold.begrunnelse':
     'Når du har oppholdt deg i et annet EØS-land i løpet av de siste 5 årene, må vi noen ganger innhente opplysninger fra dette landet. Det er fordi vi trenger opplysninger for å vurdere om du har rett til stønad.',
   'medlemskap.periodeBoddIUtlandet.sisteAdresse':
-    'Hva er den siste adressen du bodde på i',
+    'Hva er den siste adressen du bodde på i [0]?',
   'medlemskap.periodeBoddIUtlandet.land': 'I hvilket land oppholdt du deg i?',
-  'medlemskap.periodeBoddIUtlandet.begrunnelse': 'Hvorfor oppholdt du deg i',
+  'medlemskap.periodeBoddIUtlandet.begrunnelse':
+    'Hvorfor oppholdt du deg i [0]?',
   'medlemskap.periodeBoddIUtlandet.flereutenlandsopphold':
     'Har du hatt flere utenlandsopphold de siste 5 årene?',
   'medlemskap.periodeBoddIUtlandet.knapp': 'Legg til et utenlandsopphold',

--- a/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { SlettKnapp } from '../../../../components/knapper/SlettKnapp';
 import { hentTittelMedNr } from '../../../../language/utils';
 import PeriodeDatovelgere from '../../../../components/dato/PeriodeDatovelger';
-import { hentTekst } from '../../../../utils/søknad';
+import { hentTekst, hentTekstMedVariabel } from '../../../../utils/søknad';
 import {
   ILandMedKode,
   IUtenlandsopphold,
@@ -20,7 +20,6 @@ import { utenlandsoppholdLand } from './MedlemskapConfig';
 import { TextFieldMedBredde } from '../../../../components/TextFieldMedBredde';
 import EøsIdent from '../../../../components/EøsIdent';
 import { stringHarVerdiOgErIkkeTom } from '../../../../utils/typer';
-import { hentBeskjedMedNavn } from '../../../../utils/språk';
 
 const StyledTextarea = styled(Textarea)`
   width: 100%;
@@ -55,16 +54,18 @@ const Utenlandsopphold: FC<Props> = ({
   const periodeTittel = hentTittelMedNr(
     perioderBoddIUtlandet!,
     oppholdsnr,
-    intl.formatMessage({
-      id: 'medlemskap.periodeBoddIUtlandet.utenlandsopphold',
-    })
+    hentTekst('medlemskap.periodeBoddIUtlandet.utenlandsopphold', intl)
   );
-  const begrunnelseTekst = intl.formatMessage({
-    id: 'medlemskap.periodeBoddIUtlandet.begrunnelse',
-  });
-  const sisteAdresseTekst = intl.formatMessage({
-    id: 'medlemskap.periodeBoddIUtlandet.sisteAdresse',
-  });
+  const begrunnelseTekst = hentTekstMedVariabel(
+    'medlemskap.periodeBoddIUtlandet.begrunnelse',
+    intl,
+    { 0: utenlandsopphold.land?.verdi || '' }
+  );
+  const sisteAdresseTekst = hentTekstMedVariabel(
+    'medlemskap.periodeBoddIUtlandet.sisteAdresse',
+    intl,
+    { 0: utenlandsopphold.land?.verdi || '' }
+  );
 
   const landConfig = utenlandsoppholdLand(land);
 
@@ -192,10 +193,7 @@ const Utenlandsopphold: FC<Props> = ({
         // eslint-disable-next-line no-prototype-builtins
         utenlandsopphold.land?.hasOwnProperty('verdi') && (
           <StyledTextarea
-            label={hentBeskjedMedNavn(
-              utenlandsopphold.land?.verdi,
-              begrunnelseTekst
-            )}
+            label={begrunnelseTekst}
             placeholder={'...'}
             value={begrunnelse.verdi}
             maxLength={1000}
@@ -229,22 +227,10 @@ const Utenlandsopphold: FC<Props> = ({
         <TextFieldMedBredde
           className={'inputfelt-tekst'}
           key={'navn'}
-          label={hentBeskjedMedNavn(
-            utenlandsopphold.land.verdi,
-            sisteAdresseTekst
-          )}
+          label={sisteAdresseTekst}
           type="text"
           bredde={'L'}
-          onChange={(e) =>
-            settFeltNavn(
-              e,
-              'adresseEøsLand',
-              hentBeskjedMedNavn(
-                utenlandsopphold.land?.verdi || '',
-                sisteAdresseTekst
-              )
-            )
-          }
+          onChange={(e) => settFeltNavn(e, 'adresseEøsLand', sisteAdresseTekst)}
           value={adresseEøsLand?.verdi}
         />
       )}

--- a/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknad/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -20,6 +20,7 @@ import { utenlandsoppholdLand } from './MedlemskapConfig';
 import { TextFieldMedBredde } from '../../../../components/TextFieldMedBredde';
 import EøsIdent from '../../../../components/EøsIdent';
 import { stringHarVerdiOgErIkkeTom } from '../../../../utils/typer';
+import { hentBeskjedMedNavn } from '../../../../utils/språk';
 
 const StyledTextarea = styled(Textarea)`
   width: 100%;
@@ -66,13 +67,6 @@ const Utenlandsopphold: FC<Props> = ({
   });
 
   const landConfig = utenlandsoppholdLand(land);
-
-  const tekstMedLandVerdi = (tekst: string): string => {
-    if (utenlandsopphold.land) {
-      return tekst + ' ' + utenlandsopphold.land.verdi + '?';
-    }
-    return '';
-  };
 
   const fjernUtenlandsperiode = () => {
     if (perioderBoddIUtlandet && perioderBoddIUtlandet.length > 1) {
@@ -198,7 +192,10 @@ const Utenlandsopphold: FC<Props> = ({
         // eslint-disable-next-line no-prototype-builtins
         utenlandsopphold.land?.hasOwnProperty('verdi') && (
           <StyledTextarea
-            label={tekstMedLandVerdi(begrunnelseTekst)}
+            label={hentBeskjedMedNavn(
+              utenlandsopphold.land?.verdi,
+              begrunnelseTekst
+            )}
             placeholder={'...'}
             value={begrunnelse.verdi}
             maxLength={1000}
@@ -228,18 +225,24 @@ const Utenlandsopphold: FC<Props> = ({
             }
           />
         )}
-      {skalViseAdresseTekstfelt(utenlandsopphold) && (
+      {utenlandsopphold.land && skalViseAdresseTekstfelt(utenlandsopphold) && (
         <TextFieldMedBredde
           className={'inputfelt-tekst'}
           key={'navn'}
-          label={tekstMedLandVerdi(sisteAdresseTekst)}
+          label={hentBeskjedMedNavn(
+            utenlandsopphold.land.verdi,
+            sisteAdresseTekst
+          )}
           type="text"
           bredde={'L'}
           onChange={(e) =>
             settFeltNavn(
               e,
               'adresseEøsLand',
-              tekstMedLandVerdi(sisteAdresseTekst)
+              hentBeskjedMedNavn(
+                utenlandsopphold.land?.verdi || '',
+                sisteAdresseTekst
+              )
             )
           }
           value={adresseEøsLand?.verdi}

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -86,6 +86,14 @@ export const hentTekst = (id: string, intl: LokalIntlShape) => {
   return intl.formatMessage({ id: id });
 };
 
+export const hentTekstMedVariabel = (
+  id: string,
+  intl: LokalIntlShape,
+  variabel?: Record<string, string>
+) => {
+  return intl.formatMessage({ id: id }, variabel);
+};
+
 export const fraStringTilTall = (tallAvTypenStreng: string) => {
   const parsed = Number.parseInt(tallAvTypenStreng, 10);
   if (Number.isNaN(parsed)) {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Tidligere fungerte ikke tekstene i utenlandsopphold, og den fungerte ikke så bra på engelsk:
![image](https://github.com/user-attachments/assets/76763d7c-ce22-4924-a803-3538155e312e)

Også lagt til en funksjon (hentTekstMedVariabel) som håndterer både oversettelse og tillater variabler i streng. Denne kan på sikt brukes slik at tekst-håndtering blir konsekvent i repoet, da det nå skjer på mange forskjellige måter