### PR TITLE
legge til arbeidssøker søknad i ny modernisert flyt. med feturetoggle

### DIFF
--- a/src/arbeidssøkerskjema/SkjemaApp.tsx
+++ b/src/arbeidssøkerskjema/SkjemaApp.tsx
@@ -13,6 +13,8 @@ import Kvittering from './steg/3-Kvittering';
 import { SkjemaProvider } from './SkjemaContext';
 import RedirectArbeidssoker from './routes/RedirectArbeidssoker';
 import { Loader } from '@navikt/ds-react';
+import { useToggles } from '../context/TogglesContext';
+import hentToggles from '../toggles/api';
 
 const App = () => {
   const [autentisert, settAutentisering] = useState<boolean>(false);
@@ -25,8 +27,15 @@ const App = () => {
     ident,
     visningsnavn,
   };
+  const { settToggles } = useToggles();
 
   autentiseringsInterceptor();
+
+  const fetchToggles = () => {
+    return hentToggles(settToggles).catch(() => {
+      settError(true);
+    });
+  };
 
   useEffect(() => {
     verifiserAtBrukerErAutentisert(settAutentisering);
@@ -39,6 +48,9 @@ const App = () => {
           .then((response) => {
             settIdent(response.ident);
             settVisningsnavn(response.visningsnavn);
+          })
+          .then(() => {
+            fetchToggles();
 
             settError(false);
             settFeilmelding('');

--- a/src/arbeidssøkerskjema/innsending/api.ts
+++ b/src/arbeidssøkerskjema/innsending/api.ts
@@ -12,3 +12,15 @@ export const sendInnSkjema = async (skjema: object) => {
   );
   return response.data;
 };
+
+export const sendInnArbeidsøkerSkjemaFamiliePdf = async (skjema: object) => {
+  const response = await axios.post(
+    `${Environment().apiProxyUrl}/api/søknadskvittering/arbeidssoker`,
+    skjema,
+    {
+      headers: { 'Content-Type': 'application/json;charset=utf-8' },
+      withCredentials: true,
+    }
+  );
+  return response.data;
+};

--- a/src/arbeidssøkerskjema/innsending/api.ts
+++ b/src/arbeidssøkerskjema/innsending/api.ts
@@ -15,7 +15,7 @@ export const sendInnSkjema = async (skjema: object) => {
 
 export const sendInnArbeidsøkerSkjemaFamiliePdf = async (skjema: object) => {
   const response = await axios.post(
-    `${Environment().apiProxyUrl}/api/søknadskvittering/arbeidssoker`,
+    `${Environment().apiProxyUrl}/api/soknadskvittering/arbeidssoker`,
     skjema,
     {
       headers: { 'Content-Type': 'application/json;charset=utf-8' },

--- a/src/arbeidssøkerskjema/innsending/api.ts
+++ b/src/arbeidssøkerskjema/innsending/api.ts
@@ -13,7 +13,7 @@ export const sendInnSkjema = async (skjema: object) => {
   return response.data;
 };
 
-export const sendInnArbeidsøkerSkjema = async (skjema: object) => {
+export const sendInnArbeidssøkerSkjema = async (skjema: object) => {
   const response = await axios.post(
     `${Environment().apiProxyUrl}/api/soknadskvittering/arbeidssoker`,
     skjema,

--- a/src/arbeidssøkerskjema/innsending/api.ts
+++ b/src/arbeidssøkerskjema/innsending/api.ts
@@ -13,7 +13,7 @@ export const sendInnSkjema = async (skjema: object) => {
   return response.data;
 };
 
-export const sendInnArbeidsøkerSkjemaFamiliePdf = async (skjema: object) => {
+export const sendInnArbeidsøkerSkjema = async (skjema: object) => {
   const response = await axios.post(
     `${Environment().apiProxyUrl}/api/soknadskvittering/arbeidssoker`,
     skjema,

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -63,8 +63,8 @@ const Oppsummering: React.FC = () => {
   const sendInnArbeidsøkerSkjemaOgNavigerVidere = async (
     mappetSkjema: Record<string, object>
   ) => {
-    const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
     try {
+      const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
       const kvittering = brukModernisertFlyt
         ? await sendInnArbeidssøkerSkjema(mappetSkjema)
         : await sendInnSkjema(mappetSkjema);

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -60,11 +60,11 @@ const Oppsummering: React.FC = () => {
 
   useMount(() => logSidevisningArbeidssokerskjema('Oppsummering'));
 
-  const sendInnArbeidsøkerSkjemaOgNavigerVidere = async (
+  const sendInnArbeidssøkerSkjemaOgNavigerVidere = async (
     mappetSkjema: Record<string, object>
   ) => {
+    const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
     try {
-      const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
       const kvittering = brukModernisertFlyt
         ? await sendInnArbeidssøkerSkjema(mappetSkjema)
         : await sendInnSkjema(mappetSkjema);
@@ -93,7 +93,7 @@ const Oppsummering: React.FC = () => {
   const sendSkjema = (arbeidssøker: IArbeidssøker) => {
     const mappetSkjema = mapDataTilLabelOgVerdiTyper(arbeidssøker);
     settinnsendingState({ ...innsendingState, venter: true });
-    sendInnArbeidsøkerSkjemaOgNavigerVidere(mappetSkjema);
+    sendInnArbeidssøkerSkjemaOgNavigerVidere(mappetSkjema);
   };
 
   return (

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -12,10 +12,7 @@ import { useSkjema } from '../SkjemaContext';
 import { VisLabelOgSvar } from '../../utils/visning';
 import { IArbeidssøker } from '../../models/steg/aktivitet/arbeidssøker';
 import LenkeMedIkon from '../../components/knapper/LenkeMedIkon';
-import {
-  sendInnArbeidsøkerSkjemaFamiliePdf,
-  sendInnSkjema,
-} from '../innsending/api';
+import { sendInnSkjema } from '../innsending/api';
 import { IStatus } from '../innsending/typer';
 import LocaleTekst from '../../language/LocaleTekst';
 import SeksjonGruppe from '../../components/gruppe/SeksjonGruppe';
@@ -66,11 +63,10 @@ const Oppsummering: React.FC = () => {
   const sendInnArbeidsøkerSkjema = async (
     mappetSkjema: Record<string, object>
   ) => {
+    const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
     try {
-      const brukModernisertFlyt =
-        toggles[ToggleName.visNyInnsendingsknapp] || true;
       const kvittering = brukModernisertFlyt
-        ? await sendInnArbeidsøkerSkjemaFamiliePdf(mappetSkjema)
+        ? await sendInnArbeidsøkerSkjema(mappetSkjema)
         : await sendInnSkjema(mappetSkjema);
 
       settinnsendingState({

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -12,7 +12,7 @@ import { useSkjema } from '../SkjemaContext';
 import { VisLabelOgSvar } from '../../utils/visning';
 import { IArbeidssøker } from '../../models/steg/aktivitet/arbeidssøker';
 import LenkeMedIkon from '../../components/knapper/LenkeMedIkon';
-import { sendInnSkjema } from '../innsending/api';
+import { sendInnArbeidssøkerSkjema, sendInnSkjema } from '../innsending/api';
 import { IStatus } from '../innsending/typer';
 import LocaleTekst from '../../language/LocaleTekst';
 import SeksjonGruppe from '../../components/gruppe/SeksjonGruppe';
@@ -60,13 +60,13 @@ const Oppsummering: React.FC = () => {
 
   useMount(() => logSidevisningArbeidssokerskjema('Oppsummering'));
 
-  const sendInnArbeidsøkerSkjema = async (
+  const sendInnArbeidsøkerSkjemaOgNavigerVidere = async (
     mappetSkjema: Record<string, object>
   ) => {
     const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
     try {
       const kvittering = brukModernisertFlyt
-        ? await sendInnArbeidsøkerSkjema(mappetSkjema)
+        ? await sendInnArbeidssøkerSkjema(mappetSkjema)
         : await sendInnSkjema(mappetSkjema);
 
       settinnsendingState({
@@ -93,7 +93,7 @@ const Oppsummering: React.FC = () => {
   const sendSkjema = (arbeidssøker: IArbeidssøker) => {
     const mappetSkjema = mapDataTilLabelOgVerdiTyper(arbeidssøker);
     settinnsendingState({ ...innsendingState, venter: true });
-    sendInnArbeidsøkerSkjema(mappetSkjema);
+    sendInnArbeidsøkerSkjemaOgNavigerVidere(mappetSkjema);
   };
 
   return (

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -65,8 +65,6 @@ const Oppsummering: React.FC = () => {
   ) => {
     try {
       const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
-      console.log('brukModernisertFlyt:', brukModernisertFlyt);
-      console.log('toggles:', toggles);
       const kvittering = brukModernisertFlyt
         ? await sendInnArbeidssøkerSkjema(mappetSkjema)
         : await sendInnSkjema(mappetSkjema);

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -65,6 +65,8 @@ const Oppsummering: React.FC = () => {
   ) => {
     try {
       const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
+      console.log('brukModernisertFlyt:', brukModernisertFlyt);
+      console.log('toggles:', toggles);
       const kvittering = brukModernisertFlyt
         ? await sendInnArbeidssøkerSkjema(mappetSkjema)
         : await sendInnSkjema(mappetSkjema);

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -67,7 +67,10 @@ const Oppsummering: React.FC = () => {
     mappetSkjema: Record<string, object>
   ) => {
     try {
-      const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
+      console.log('mappetSkjema', mappetSkjema);
+
+      const brukModernisertFlyt =
+        toggles[ToggleName.visNyInnsendingsknapp] || true;
       const kvittering = brukModernisertFlyt
         ? await sendInnArbeidsøkerSkjemaFamiliePdf(mappetSkjema)
         : await sendInnSkjema(mappetSkjema);
@@ -94,6 +97,8 @@ const Oppsummering: React.FC = () => {
   };
 
   const sendSkjema = (arbeidssøker: IArbeidssøker) => {
+    console.log('send skjema');
+
     const mappetSkjema = mapDataTilLabelOgVerdiTyper(arbeidssøker);
     settinnsendingState({ ...innsendingState, venter: true });
     sendInnArbeidsøkerSkjema(mappetSkjema);

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -67,8 +67,6 @@ const Oppsummering: React.FC = () => {
     mappetSkjema: Record<string, object>
   ) => {
     try {
-      console.log('mappetSkjema', mappetSkjema);
-
       const brukModernisertFlyt =
         toggles[ToggleName.visNyInnsendingsknapp] || true;
       const kvittering = brukModernisertFlyt
@@ -97,8 +95,6 @@ const Oppsummering: React.FC = () => {
   };
 
   const sendSkjema = (arbeidssøker: IArbeidssøker) => {
-    console.log('send skjema');
-
     const mappetSkjema = mapDataTilLabelOgVerdiTyper(arbeidssøker);
     settinnsendingState({ ...innsendingState, venter: true });
     sendInnArbeidsøkerSkjema(mappetSkjema);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Legge til arbeidsøkerskjema i ny flyt. 
- Egen funksjon `SendInnArbeidssøkerSkjemaFamiliePdf` for å bruke vår nye flyt (søknadskvittering)
- feature toggle for å bruke ny eller eksisterende flyt
