### PR TITLE
Feature - søknadsflyten formidler når sist innsendte søknad var mottatt, samt lenker til eksterne resurser

### DIFF
--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -1,14 +1,14 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import axios from 'axios';
 import { Alert, Heading } from '@navikt/ds-react';
 import { Stønadstype } from '../../models/søknad/stønadstyper';
 import Environment from '../../Environment';
 import { useToggles } from '../../context/TogglesContext';
 import { ToggleName } from '../../models/søknad/toggles';
-import { formatDate } from '../../utils/dato';
+import { formatDate, strengTilDato } from '../../utils/dato';
 
 export interface SistInnsendteSøknad {
-  søknadsdato: Date;
+  søknadsdato: string;
   stønadType: Stønadstype;
 }
 
@@ -27,17 +27,14 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
     SistInnsendteSøknad[]
   >([]);
 
-  const ettersendUrls = useMemo(
-    () => ({
-      [Stønadstype.overgangsstønad]:
-        'https://www.nav.no/start/ettersend-soknad-overgangsstonad-enslig',
-      [Stønadstype.barnetilsyn]:
-        'https://www.nav.no/start/ettersend-soknad-barnetilsyn-enslig',
-      [Stønadstype.skolepenger]:
-        'https://www.nav.no/start/ettersend-soknad-skolepenger-enslig',
-    }),
-    []
-  );
+  const ettersendingUrler = {
+    [Stønadstype.overgangsstønad]:
+      'https://www.nav.no/start/ettersend-soknad-overgangsstonad-enslig',
+    [Stønadstype.barnetilsyn]:
+      'https://www.nav.no/start/ettersend-soknad-barnetilsyn-enslig',
+    [Stønadstype.skolepenger]:
+      'https://www.nav.no/start/ettersend-soknad-skolepenger-enslig',
+  };
 
   const kontaktOssUrl = 'https://www.nav.no/kontakt-oss';
 
@@ -77,13 +74,13 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
         Du har nylig sendt inn en søknad til oss
       </Heading>
       <p>
-        {`Du søkte om ${stønadType} den ${formatDate(gjeldeneSøknad.søknadsdato)}.`}
+        {`Du søkte om ${stønadType} den ${formatDate(strengTilDato(gjeldeneSøknad.søknadsdato))}.`}
       </p>
       <ul>
         <li>
           Hvis du ikke fikk lastet opp all dokumentasjon da du søkte, kan du{' '}
           <a
-            href={ettersendUrls[stønadType]}
+            href={ettersendingUrler[stønadType]}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import { Alert, Heading } from '@navikt/ds-react';
 import { Stønadstype } from '../../models/søknad/stønadstyper';
@@ -16,17 +16,6 @@ interface TidligereInnsendteSøknadAlertProps {
   stønadType: Stønadstype;
 }
 
-const ettersendUrls = {
-  [Stønadstype.overgangsstønad]:
-    'https://www.nav.no/start/ettersend-soknad-overgangsstonad-enslig',
-  [Stønadstype.barnetilsyn]:
-    'https://www.nav.no/start/ettersend-soknad-barnetilsyn-enslig',
-  [Stønadstype.skolepenger]:
-    'https://www.nav.no/start/ettersend-soknad-skolepenger-enslig',
-};
-
-const kontaktOssUrl = 'https://www.nav.no/kontakt-oss';
-
 export const TidligereInnsendteSøknaderAlert: React.FC<
   TidligereInnsendteSøknadAlertProps
 > = ({ stønadType }) => {
@@ -38,11 +27,24 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
     SistInnsendteSøknad[]
   >([]);
 
+  const ettersendUrls = useMemo(
+    () => ({
+      [Stønadstype.overgangsstønad]:
+        'https://www.nav.no/start/ettersend-soknad-overgangsstonad-enslig',
+      [Stønadstype.barnetilsyn]:
+        'https://www.nav.no/start/ettersend-soknad-barnetilsyn-enslig',
+      [Stønadstype.skolepenger]:
+        'https://www.nav.no/start/ettersend-soknad-skolepenger-enslig',
+    }),
+    []
+  );
+
+  const kontaktOssUrl = 'https://www.nav.no/kontakt-oss';
+
   const hentInnsendteSøknader = useCallback(() => {
     axios
       .get<SistInnsendteSøknad[]>(
-        Environment().apiProxyUrl +
-          '/api/soknadskvittering/sist-innsendt-per-stonad'
+        `${Environment().apiProxyUrl}/api/soknadskvittering/sist-innsendt-per-stonad`
       )
       .then((response) => {
         settInnsendteSøknader(response.data);
@@ -61,46 +63,40 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
     }
   }, [hentInnsendteSøknader, hentSistInnsendteSøknadPerStønad]);
 
-  const visNylingInnsendtSøknadAlert = innsendteSøknader.some(
-    (søknad) => søknad.stønadType.valueOf().toLowerCase() === stønadType
-  );
-
   const gjeldeneSøknad = innsendteSøknader.find(
     (søknad) => søknad.stønadType.valueOf().toLowerCase() === stønadType
   );
 
-  if (gjeldeneSøknad != null) {
-    return (
-      <>
-        {visNylingInnsendtSøknadAlert && (
-          <Alert variant="info">
-            <Heading spacing size="small" level="3">
-              Du har nylig sendt inn en søknad til oss
-            </Heading>
-            <p>
-              {`Du søkte om ${stønadType} den ${formatDate(gjeldeneSøknad.søknadsdato)}.`}
-            </p>
-            <p>
-              Hvis du ikke fikk lastet opp all dokumentasjon da du søkte, kan du{' '}
-              <a
-                href={ettersendUrls[stønadType]}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                ettersende det som mangler
-              </a>
-              .
-            </p>
-            <p>
-              Du kan også si ifra om endringer ved å{' '}
-              <a href={kontaktOssUrl} target="_blank" rel="noopener noreferrer">
-                skrive en beskjed til oss
-              </a>
-              .
-            </p>
-          </Alert>
-        )}
-      </>
-    );
+  if (!gjeldeneSøknad) {
+    return null;
   }
+
+  return (
+    <Alert variant="info">
+      <Heading spacing size="small" level="3">
+        Du har nylig sendt inn en søknad til oss
+      </Heading>
+      <p>
+        {`Du søkte om ${stønadType} den ${formatDate(gjeldeneSøknad.søknadsdato)}.`}
+      </p>
+      <p>
+        Hvis du ikke fikk lastet opp all dokumentasjon da du søkte, kan du{' '}
+        <a
+          href={ettersendUrls[stønadType]}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ettersende det som mangler
+        </a>
+        .
+      </p>
+      <p>
+        Du kan også si ifra om endringer ved å{' '}
+        <a href={kontaktOssUrl} target="_blank" rel="noopener noreferrer">
+          skrive en beskjed til oss
+        </a>
+        .
+      </p>
+    </Alert>
+  );
 };

--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -5,15 +5,27 @@ import { Stønadstype } from '../../models/søknad/stønadstyper';
 import Environment from '../../Environment';
 import { useToggles } from '../../context/TogglesContext';
 import { ToggleName } from '../../models/søknad/toggles';
+import { formatDate } from '../../utils/dato';
 
 export interface SistInnsendteSøknad {
-  søknadsdato: string;
+  søknadsdato: Date;
   stønadType: Stønadstype;
 }
 
 interface TidligereInnsendteSøknadAlertProps {
   stønadType: Stønadstype;
 }
+
+const ettersendUrls = {
+  [Stønadstype.overgangsstønad]:
+    'https://www.nav.no/start/ettersend-soknad-overgangsstonad-enslig',
+  [Stønadstype.barnetilsyn]:
+    'https://www.nav.no/start/ettersend-soknad-barnetilsyn-enslig',
+  [Stønadstype.skolepenger]:
+    'https://www.nav.no/start/ettersend-soknad-skolepenger-enslig',
+};
+
+const kontaktOssUrl = 'https://www.nav.no/kontakt-oss';
 
 export const TidligereInnsendteSøknaderAlert: React.FC<
   TidligereInnsendteSøknadAlertProps
@@ -53,26 +65,42 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
     (søknad) => søknad.stønadType.valueOf().toLowerCase() === stønadType
   );
 
-  return (
-    <>
-      {visNylingInnsendtSøknadAlert && (
-        <Alert variant="info">
-          <Heading spacing size="small" level="3">
-            Du har allerede en aktiv søknad hos oss
-          </Heading>
-          <p>
-            Vi ser at du nylig har sendt inn denne søknaden. Dersom du sender
-            søknaden på nytt, vil behandlingen ta lenger tid. Ønsker du å
-            opplyse om endringer eller noe nytt kan du gjøre følgende:
-          </p>
-          <ul>
-            <li>Endre kontonummeret.</li>
-            <li>Melde fra om frivillig skattetrekk på barnepensjonen.</li>
-            <li>Ettersende dokumentasjon.</li>
-            <li>Er det noe annet du ønsker å melde inn kan du kontakte oss.</li>
-          </ul>
-        </Alert>
-      )}
-    </>
+  const gjeldeneSøknad = innsendteSøknader.find(
+    (søknad) => søknad.stønadType.valueOf().toLowerCase() === stønadType
   );
+
+  if (gjeldeneSøknad != null) {
+    return (
+      <>
+        {visNylingInnsendtSøknadAlert && (
+          <Alert variant="info">
+            <Heading spacing size="small" level="3">
+              Du har nylig sendt inn en søknad til oss
+            </Heading>
+            <p>
+              {`Du søkte om ${stønadType} den ${formatDate(gjeldeneSøknad.søknadsdato)}.`}
+            </p>
+            <p>
+              Hvis du ikke fikk lastet opp all dokumentasjon da du søkte, kan du{' '}
+              <a
+                href={ettersendUrls[stønadType]}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ettersende det som mangler
+              </a>
+              .
+            </p>
+            <p>
+              Du kan også si ifra om endringer ved å{' '}
+              <a href={kontaktOssUrl} target="_blank" rel="noopener noreferrer">
+                skrive en beskjed til oss
+              </a>
+              .
+            </p>
+          </Alert>
+        )}
+      </>
+    );
+  }
 };

--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -79,24 +79,26 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
       <p>
         {`Du søkte om ${stønadType} den ${formatDate(gjeldeneSøknad.søknadsdato)}.`}
       </p>
-      <p>
-        Hvis du ikke fikk lastet opp all dokumentasjon da du søkte, kan du{' '}
-        <a
-          href={ettersendUrls[stønadType]}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ettersende det som mangler
-        </a>
-        .
-      </p>
-      <p>
-        Du kan også si ifra om endringer ved å{' '}
-        <a href={kontaktOssUrl} target="_blank" rel="noopener noreferrer">
-          skrive en beskjed til oss
-        </a>
-        .
-      </p>
+      <ul>
+        <li>
+          Hvis du ikke fikk lastet opp all dokumentasjon da du søkte, kan du{' '}
+          <a
+            href={ettersendUrls[stønadType]}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ettersende det som mangler
+          </a>
+          .
+        </li>
+        <li>
+          Du kan også si ifra om endringer ved å{' '}
+          <a href={kontaktOssUrl} target="_blank" rel="noopener noreferrer">
+            skrive en beskjed til oss
+          </a>
+          .
+        </li>
+      </ul>
     </Alert>
   );
 };


### PR DESCRIPTION
# Søknadsflyten formidler når sist innsendte søknad var mottatt, samt lenker til eksterne resurser

![Skjermbilde 2025-02-13 kl  13 13 10](https://github.com/user-attachments/assets/3b8c981a-1b51-4d74-916c-9be970f17b01)

### Hvorfor er denne endringen nødvendig? ✨ 

Vi har fått avklart tekster for tidligere innsendt søknad varsel. Derfor introduserer denne PRen nye endringer til alerten der vi nå viser når sist innsendte søknad var mottatt (per stønadstype), linker til ettersending (per stønadtype) og linker til kontakt oss (samme for alle). 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23469).

### Verdt å nevne

* Lenkene går direkte mot ekstern. Kunne være fint å ha de peke mot de respektive miljøene, men ser at det linkes ut mot eksternt andre steder i repoet, så tenker det er greit.
* Har testet og sjekket at lenkene fungerer og peker riktig per stønadsflyt. 