### PR TITLE
Feature - tidligere innsendt søknad varsel støtter nå Engelsk og Nynorsk

### DIFF
--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -100,30 +100,30 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
     },
   };
 
-  const relevanteTekster = tekster[locale];
+  const varselTekster = tekster[locale];
 
   return (
     <Alert variant="info">
       <Heading spacing size="small" level="3">
-        {relevanteTekster.heading}
+        {varselTekster.heading}
       </Heading>
-      <p>{relevanteTekster.søkteOm}</p>
+      <p>{varselTekster.søkteOm}</p>
       <ul>
         <li>
-          {relevanteTekster.ettersende}{' '}
+          {varselTekster.ettersende}{' '}
           <a
             href={ettersendUrls[stønadType]}
             target="_blank"
             rel="noopener noreferrer"
           >
-            {relevanteTekster.ettersendeLink}
+            {varselTekster.ettersendeLink}
           </a>
           .
         </li>
         <li>
-          {relevanteTekster.endringer}{' '}
+          {varselTekster.endringer}{' '}
           <a href={kontaktOssUrl} target="_blank" rel="noopener noreferrer">
-            {relevanteTekster.endringerLink}
+            {varselTekster.endringerLink}
           </a>
           .
         </li>

--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -100,30 +100,30 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
     },
   };
 
-  const currentTexts = tekster[locale];
+  const relevanteTekster = tekster[locale];
 
   return (
     <Alert variant="info">
       <Heading spacing size="small" level="3">
-        {currentTexts.heading}
+        {relevanteTekster.heading}
       </Heading>
-      <p>{currentTexts.søkteOm}</p>
+      <p>{relevanteTekster.søkteOm}</p>
       <ul>
         <li>
-          {currentTexts.ettersende}{' '}
+          {relevanteTekster.ettersende}{' '}
           <a
             href={ettersendUrls[stønadType]}
             target="_blank"
             rel="noopener noreferrer"
           >
-            {currentTexts.ettersendeLink}
+            {relevanteTekster.ettersendeLink}
           </a>
           .
         </li>
         <li>
-          {currentTexts.endringer}{' '}
+          {relevanteTekster.endringer}{' '}
           <a href={kontaktOssUrl} target="_blank" rel="noopener noreferrer">
-            {currentTexts.endringerLink}
+            {relevanteTekster.endringerLink}
           </a>
           .
         </li>

--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -17,7 +17,7 @@ interface TidligereInnsendteSøknadAlertProps {
   stønadType: Stønadstype;
 }
 
-const ettersendUrls = {
+const ettersendingUrler = {
   [Stønadstype.overgangsstønad]:
     'https://www.nav.no/start/ettersend-soknad-overgangsstonad-enslig',
   [Stønadstype.barnetilsyn]:
@@ -112,7 +112,7 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
         <li>
           {varselTekster.ettersende}{' '}
           <a
-            href={ettersendUrls[stønadType]}
+            href={ettersendingUrler[stønadType]}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
+++ b/src/components/forside/TidligereInnsendteSøknaderAlert.tsx
@@ -6,6 +6,7 @@ import Environment from '../../Environment';
 import { useToggles } from '../../context/TogglesContext';
 import { ToggleName } from '../../models/søknad/toggles';
 import { formatDate, strengTilDato } from '../../utils/dato';
+import { useSpråkContext } from '../../context/SpråkContext';
 
 export interface SistInnsendteSøknad {
   søknadsdato: string;
@@ -16,27 +17,28 @@ interface TidligereInnsendteSøknadAlertProps {
   stønadType: Stønadstype;
 }
 
+const ettersendUrls = {
+  [Stønadstype.overgangsstønad]:
+    'https://www.nav.no/start/ettersend-soknad-overgangsstonad-enslig',
+  [Stønadstype.barnetilsyn]:
+    'https://www.nav.no/start/ettersend-soknad-barnetilsyn-enslig',
+  [Stønadstype.skolepenger]:
+    'https://www.nav.no/start/ettersend-soknad-skolepenger-enslig',
+};
+
+const kontaktOssUrl = 'https://www.nav.no/kontakt-oss';
+
 export const TidligereInnsendteSøknaderAlert: React.FC<
   TidligereInnsendteSøknadAlertProps
 > = ({ stønadType }) => {
   const { toggles } = useToggles();
   const hentSistInnsendteSøknadPerStønad =
     toggles[ToggleName.hentSistInnsendteSøknadPerStønad];
+  const [locale] = useSpråkContext();
 
   const [innsendteSøknader, settInnsendteSøknader] = useState<
     SistInnsendteSøknad[]
   >([]);
-
-  const ettersendingUrler = {
-    [Stønadstype.overgangsstønad]:
-      'https://www.nav.no/start/ettersend-soknad-overgangsstonad-enslig',
-    [Stønadstype.barnetilsyn]:
-      'https://www.nav.no/start/ettersend-soknad-barnetilsyn-enslig',
-    [Stønadstype.skolepenger]:
-      'https://www.nav.no/start/ettersend-soknad-skolepenger-enslig',
-  };
-
-  const kontaktOssUrl = 'https://www.nav.no/kontakt-oss';
 
   const hentInnsendteSøknader = useCallback(() => {
     axios
@@ -68,30 +70,60 @@ export const TidligereInnsendteSøknaderAlert: React.FC<
     return null;
   }
 
+  const tekster = {
+    nb: {
+      heading: 'Du har nylig sendt inn en søknad til oss',
+      søkteOm: `Du søkte om ${stønadType} den ${formatDate(strengTilDato(gjeldeneSøknad.søknadsdato))}.`,
+      ettersende:
+        'Hvis du ikke fikk lastet opp all dokumentasjon da du søkte, kan du',
+      ettersendeLink: 'ettersende det som mangler',
+      endringer: 'Du kan også si ifra om endringer ved å',
+      endringerLink: 'skrive en beskjed til oss',
+    },
+    nn: {
+      heading: 'Du har nyleg sendt inn ein søknad til oss',
+      søkteOm: `Du søkte om ${stønadType} den ${formatDate(strengTilDato(gjeldeneSøknad.søknadsdato))}.`,
+      ettersende:
+        'Viss du ikkje fekk lasta opp all dokumentasjon då du søkte, kan du',
+      ettersendeLink: 'ettersenda det som manglar',
+      endringer: 'Du kan òg seie ifrå om endringar ved å',
+      endringerLink: 'skrive ei melding til oss',
+    },
+    en: {
+      heading: 'You have recently submitted an application to us',
+      søkteOm: `You applied for ${stønadType} on ${formatDate(strengTilDato(gjeldeneSøknad.søknadsdato))}.`,
+      ettersende:
+        'If you did not upload all the documentation when you applied, you can',
+      ettersendeLink: 'submit the missing documents',
+      endringer: 'You can also notify us of changes by',
+      endringerLink: 'writing a message to us',
+    },
+  };
+
+  const currentTexts = tekster[locale];
+
   return (
     <Alert variant="info">
       <Heading spacing size="small" level="3">
-        Du har nylig sendt inn en søknad til oss
+        {currentTexts.heading}
       </Heading>
-      <p>
-        {`Du søkte om ${stønadType} den ${formatDate(strengTilDato(gjeldeneSøknad.søknadsdato))}.`}
-      </p>
+      <p>{currentTexts.søkteOm}</p>
       <ul>
         <li>
-          Hvis du ikke fikk lastet opp all dokumentasjon da du søkte, kan du{' '}
+          {currentTexts.ettersende}{' '}
           <a
-            href={ettersendingUrler[stønadType]}
+            href={ettersendUrls[stønadType]}
             target="_blank"
             rel="noopener noreferrer"
           >
-            ettersende det som mangler
+            {currentTexts.ettersendeLink}
           </a>
           .
         </li>
         <li>
-          Du kan også si ifra om endringer ved å{' '}
+          {currentTexts.endringer}{' '}
           <a href={kontaktOssUrl} target="_blank" rel="noopener noreferrer">
-            skrive en beskjed til oss
+            {currentTexts.endringerLink}
           </a>
           .
         </li>


### PR DESCRIPTION
# Tidligere innsendt søknad varsel støtter nå Engelsk og Nynorsk

### Hvorfor er denne endringen nødvendig? ✨ 

![Skjermbilde 2025-02-13 kl  15 05 37](https://github.com/user-attachments/assets/3c7d3029-c3b5-4c55-b487-a6b34d277cdc)

Vi må støtte flere språk. Derfor støtter vi nå Engelsk og Nynorsk.