### PR TITLE
Bug - søknader for barnetilsyn og skolepenger sender nå med locale

### DIFF
--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -67,6 +67,7 @@ const initialState = (intl: LokalIntlShape): ISøknad => {
     dokumentasjonsbehov: [],
     harBekreftet: false,
     datoPåbegyntSøknad: formatIsoDate(dagensDato),
+    locale: '',
   };
 };
 

--- a/src/barnetilsyn/models/søknad.ts
+++ b/src/barnetilsyn/models/søknad.ts
@@ -24,6 +24,7 @@ export interface ISøknad {
   dokumentasjonsbehov: IDokumentasjon[];
   harBekreftet: boolean;
   datoPåbegyntSøknad?: string;
+  locale: string;
 }
 
 export interface ForrigeSøknad {

--- a/src/barnetilsyn/steg/8-dokumentasjon/SendBarnetilsynSøknad.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/SendBarnetilsynSøknad.tsx
@@ -37,6 +37,7 @@ import { oppdaterBarnLabels } from '../../../utils/barn';
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
 import { useToggles } from '../../../context/TogglesContext';
 import { ToggleName } from '../../../models/søknad/toggles';
+import { useSpråkContext } from '../../../context/SpråkContext';
 
 interface Innsending {
   status: string;
@@ -57,6 +58,7 @@ const SendSøknadKnapper: FC = () => {
   const forrigeRoute = hentForrigeRoute(RoutesBarnetilsyn, location.pathname);
   const skjemaId = skjemanavnIdMapping[ESkjemanavn.Barnetilsyn];
   const intl = useLokalIntlContext();
+  const [locale] = useSpråkContext();
 
   const [innsendingState, settinnsendingState] = React.useState<Innsending>({
     status: IStatus.KLAR_TIL_INNSENDING,
@@ -112,11 +114,11 @@ const SendSøknadKnapper: FC = () => {
       unikeDokumentasjonsbehov
     );
     logDokumetasjonsbehov(dokumentasjonsbehov, ESkjemanavn.Barnetilsyn);
-
     const søknadMedFiltrerteBarn: ISøknad = {
       ...søknad,
       person: { ...søknad.person, barn: barnMedOppdaterteLabels },
       dokumentasjonsbehov: dokumentasjonsbehov,
+      locale: locale,
     };
     settinnsendingState({ ...innsendingState, venter: true });
     sendInnSøknad(søknadMedFiltrerteBarn);

--- a/src/context/SøknadContext.tsx
+++ b/src/context/SøknadContext.tsx
@@ -69,6 +69,7 @@ const initialState = (intl: LokalIntlShape): ISøknad => {
     dokumentasjonsbehov: [],
     harBekreftet: false,
     datoPåbegyntSøknad: formatIsoDate(dagensDato),
+    locale: '',
   };
 };
 

--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -860,7 +860,7 @@ export default {
   'barnepass.dokumentasjon.arbeidstid':
     'You must provide documentation of your working hours.',
   'barnepass.spm.hvaSlagsOrdning':
-    'What kind of child minding arrangements does [0] have??',
+    'What kind of child minding arrangements does [0] have?',
   'hvaSlagsOrdning.svar.barnehageOgLiknende':
     'Kindergarten, child care at school outside school hours (SFO) or similar',
   'hvaSlagsOrdning.svar.privat':

--- a/src/models/søknad/søknad.ts
+++ b/src/models/søknad/søknad.ts
@@ -21,7 +21,7 @@ export interface ISøknad {
   merOmDinSituasjon: IDinSituasjon;
   dokumentasjonsbehov: IDokumentasjon[];
   harBekreftet: boolean;
-  locale?: any;
+  locale: any;
   skalBehandlesINySaksbehandling?: boolean;
   datoPåbegyntSøknad?: string;
 }

--- a/src/skolepenger/SkolepengerContext.tsx
+++ b/src/skolepenger/SkolepengerContext.tsx
@@ -62,6 +62,7 @@ const initialState = (intl: LokalIntlShape): ISøknad => {
       },
     ],
     harBekreftet: false,
+    locale: '',
   };
 };
 

--- a/src/skolepenger/models/søknad.ts
+++ b/src/skolepenger/models/søknad.ts
@@ -18,4 +18,5 @@ export interface ISøknad {
   utdanning: IDetaljertUtdanning;
   dokumentasjonsbehov: IDokumentasjon[];
   harBekreftet: boolean;
+  locale: string;
 }

--- a/src/skolepenger/steg/7-dokumentasjon/SendSkolepengerSøknad.tsx
+++ b/src/skolepenger/steg/7-dokumentasjon/SendSkolepengerSøknad.tsx
@@ -33,6 +33,7 @@ import { Alert, BodyShort, Button } from '@navikt/ds-react';
 import { validerSøkerBosattINorgeSisteFemÅr } from '../../../helpers/steg/omdeg';
 import { useToggles } from '../../../context/TogglesContext';
 import { ToggleName } from '../../../models/søknad/toggles';
+import { useSpråkContext } from '../../../context/SpråkContext';
 
 interface Innsending {
   status: string;
@@ -49,6 +50,7 @@ const SendSøknadKnapper: FC = () => {
   const forrigeRoute = hentForrigeRoute(RoutesSkolepenger, location.pathname);
   const skjemaId = skjemanavnIdMapping[ESkjemanavn.Skolepenger];
   const intl = useLokalIntlContext();
+  const [locale] = useSpråkContext();
 
   const [innsendingState, settinnsendingState] = React.useState<Innsending>({
     status: IStatus.KLAR_TIL_INNSENDING,
@@ -105,6 +107,7 @@ const SendSøknadKnapper: FC = () => {
       ...søknad,
       person: { ...søknad.person, barn: barnMedOppdaterteLabels },
       dokumentasjonsbehov: dokumentasjonsbehov,
+      locale: locale,
     };
 
     settinnsendingState({ ...innsendingState, venter: true });


### PR DESCRIPTION
# Søknader for barnetilsyn og skolepenger sender nå med locale

### Hvorfor er denne endringen nødvendig? ✨ 

Ved valg av språk dukker ikke forventet språk opp i søknadskvitteringen. Dette kan skyldes at locale aldri var sendt med for barnetilsyn og skolepenger søknader. Vi sender nå med denne verdien og mange av de labelene i kvitteringen er nå på riktig språk. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24127).

### Verdt å nevne

Vi har kun testet ved å sjekke kvitteringene for søknadene i pre-prod. Det er fortsatt noen labels som feiler, men dette skyldes andre årsaker. Dette er en gradvis-fiks av label korrigering. 