### PR TITLE
skal fjerne feature-toggle for gammel vs. ny innsendingsflyt

### DIFF
--- a/src/arbeidssøkerskjema/innsending/api.ts
+++ b/src/arbeidssøkerskjema/innsending/api.ts
@@ -1,18 +1,6 @@
 import axios from 'axios';
 import Environment from '../../Environment';
 
-export const sendInnSkjema = async (skjema: object) => {
-  const response = await axios.post(
-    `${Environment().apiProxyUrl}/api/registrerarbeid`,
-    skjema,
-    {
-      headers: { 'Content-Type': 'application/json;charset=utf-8' },
-      withCredentials: true,
-    }
-  );
-  return response.data;
-};
-
 export const sendInnArbeidssøkerSkjema = async (skjema: object) => {
   const response = await axios.post(
     `${Environment().apiProxyUrl}/api/soknadskvittering/arbeidssoker`,

--- a/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
+++ b/src/arbeidssøkerskjema/steg/2-Oppsummering.tsx
@@ -12,7 +12,7 @@ import { useSkjema } from '../SkjemaContext';
 import { VisLabelOgSvar } from '../../utils/visning';
 import { IArbeidssøker } from '../../models/steg/aktivitet/arbeidssøker';
 import LenkeMedIkon from '../../components/knapper/LenkeMedIkon';
-import { sendInnArbeidssøkerSkjema, sendInnSkjema } from '../innsending/api';
+import { sendInnArbeidssøkerSkjema } from '../innsending/api';
 import { IStatus } from '../innsending/typer';
 import LocaleTekst from '../../language/LocaleTekst';
 import SeksjonGruppe from '../../components/gruppe/SeksjonGruppe';
@@ -28,8 +28,6 @@ import { logSidevisningArbeidssokerskjema } from '../../utils/amplitude';
 import { useMount } from '../../utils/hooks';
 import { useLokalIntlContext } from '../../context/LokalIntlContext';
 import { Alert, BodyShort, Button, Heading } from '@navikt/ds-react';
-import { useToggles } from '../../context/TogglesContext';
-import { ToggleName } from '../../models/søknad/toggles';
 
 interface Innsending {
   status: IStatus;
@@ -39,7 +37,6 @@ interface Innsending {
 
 const Oppsummering: React.FC = () => {
   const location = useLocation();
-  const { toggles } = useToggles();
   const navigate = useNavigate();
   const intl = useLokalIntlContext();
   const { skjema, settSkjema } = useSkjema();
@@ -63,11 +60,8 @@ const Oppsummering: React.FC = () => {
   const sendInnArbeidssøkerSkjemaOgNavigerVidere = async (
     mappetSkjema: Record<string, object>
   ) => {
-    const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
     try {
-      const kvittering = brukModernisertFlyt
-        ? await sendInnArbeidssøkerSkjema(mappetSkjema)
-        : await sendInnSkjema(mappetSkjema);
+      const kvittering = await sendInnArbeidssøkerSkjema(mappetSkjema);
 
       settinnsendingState({
         ...innsendingState,

--- a/src/barnetilsyn/steg/8-dokumentasjon/SendBarnetilsynSøknad.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/SendBarnetilsynSøknad.tsx
@@ -10,7 +10,6 @@ import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import {
   mapBarnTilEntenIdentEllerFødselsdato,
   sendInnBarnetilsynSøknad,
-  sendInnBarnetilsynSøknadFamiliePdf,
 } from '../../../innsending/api';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 import { ISøknad } from '../../models/søknad';
@@ -35,8 +34,6 @@ import {
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 import { oppdaterBarnLabels } from '../../../utils/barn';
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
-import { useToggles } from '../../../context/TogglesContext';
-import { ToggleName } from '../../../models/søknad/toggles';
 import { useSpråkContext } from '../../../context/SpråkContext';
 
 interface Innsending {
@@ -50,7 +47,6 @@ const validerSøkerBosattINorgeSisteFemÅr = (søknad: ISøknad) => {
 };
 
 const SendSøknadKnapper: FC = () => {
-  const { toggles } = useToggles();
   const { søknad, settSøknad } = useBarnetilsynSøknad();
   const location = useLocation();
   const navigate = useNavigate();
@@ -72,11 +68,7 @@ const SendSøknadKnapper: FC = () => {
 
   const sendInnSøknad = async (søknadMedFiltrerteBarn: ISøknad) => {
     try {
-      const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
-
-      const kvittering = brukModernisertFlyt
-        ? await sendInnBarnetilsynSøknadFamiliePdf(søknadMedFiltrerteBarn)
-        : await sendInnBarnetilsynSøknad(søknadMedFiltrerteBarn);
+      const kvittering = await sendInnBarnetilsynSøknad(søknadMedFiltrerteBarn);
 
       settinnsendingState({
         ...innsendingState,

--- a/src/innsending/api.ts
+++ b/src/innsending/api.ts
@@ -4,17 +4,6 @@ import { IBarn } from '../models/steg/barn';
 
 export const sendInnOvergangstønadSøknad = (søknad: object) => {
   return axios
-    .post(`${Environment().apiProxyUrl}/api/soknad`, søknad, {
-      headers: { 'Content-Type': 'application/json;charset=utf-8' },
-      withCredentials: true,
-    })
-    .then((response: { data: any }) => {
-      return response.data;
-    });
-};
-
-export const sendInnSøknadFamiliePdf = (søknad: object) => {
-  return axios
     .post(
       `${Environment().apiProxyUrl}/api/soknadskvittering/overgangsstonad`,
       søknad,
@@ -30,16 +19,6 @@ export const sendInnSøknadFamiliePdf = (søknad: object) => {
 
 export const sendInnBarnetilsynSøknad = (søknad: object) => {
   return axios
-    .post(`${Environment().apiProxyUrl}/api/soknadbarnetilsyn`, søknad, {
-      headers: { 'Content-Type': 'application/json;charset=utf-8' },
-      withCredentials: true,
-    })
-    .then((response: { data: any }) => {
-      return response.data;
-    });
-};
-export const sendInnBarnetilsynSøknadFamiliePdf = (søknad: object) => {
-  return axios
     .post(
       `${Environment().apiProxyUrl}/api/soknadskvittering/barnetilsyn`,
       søknad,
@@ -54,17 +33,6 @@ export const sendInnBarnetilsynSøknadFamiliePdf = (søknad: object) => {
 };
 
 export const sendInnSkolepengerSøknad = (søknad: object) => {
-  return axios
-    .post(`${Environment().apiProxyUrl}/api/soknad/skolepenger`, søknad, {
-      headers: { 'Content-Type': 'application/json;charset=utf-8' },
-      withCredentials: true,
-    })
-    .then((response: { data: any }) => {
-      return response.data;
-    });
-};
-
-export const sendInnSkolepengerSøknadFamiliePdf = (søknad: object) => {
   return axios
     .post(
       `${Environment().apiProxyUrl}/api/soknadskvittering/skolepenger`,

--- a/src/models/søknad/toggles.ts
+++ b/src/models/søknad/toggles.ts
@@ -5,6 +5,5 @@ export interface Toggles {
 export enum ToggleName {
   feilsituasjon = 'familie.ef.soknad.feilsituasjon',
   leggTilNynorsk = 'familie.ef.soknad.nynorsk',
-  visNyInnsendingsknapp = 'familie.ef.soknad-ny-pdfkvittering',
   hentSistInnsendteSøknadPerStønad = 'familie.ef.soknad.frontend.hent-sist-innsendte-soknad-per-stonad',
 }

--- a/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
+++ b/src/overgangsstønad/steg/8-dokumentasjon/SendSøknad.tsx
@@ -18,7 +18,6 @@ import {
   mapBarnTilEntenIdentEllerFødselsdato,
   mapBarnUtenBarnepass,
   sendInnOvergangstønadSøknad,
-  sendInnSøknadFamiliePdf,
 } from '../../../innsending/api';
 import { hentForrigeRoute, hentNesteRoute } from '../../../utils/routing';
 import { unikeDokumentasjonsbehov } from '../../../utils/søknad';
@@ -32,8 +31,6 @@ import {
 import { ESkjemanavn, skjemanavnIdMapping } from '../../../utils/skjemanavn';
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
 import { validerSøkerBosattINorgeSisteFemÅr } from '../../../helpers/steg/omdeg';
-import { useToggles } from '../../../context/TogglesContext';
-import { ToggleName } from '../../../models/søknad/toggles';
 
 interface Innsending {
   status: string;
@@ -42,7 +39,6 @@ interface Innsending {
 }
 
 const SendSøknadKnapper: FC = () => {
-  const { toggles } = useToggles();
   const { søknad, settSøknad } = useSøknad();
   const location = useLocation();
   const [locale] = useSpråkContext();
@@ -63,11 +59,9 @@ const SendSøknadKnapper: FC = () => {
 
   const sendInnSøknad = async (søknadMedFiltrerteBarn: ISøknad) => {
     try {
-      const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
-
-      const kvittering = brukModernisertFlyt
-        ? await sendInnSøknadFamiliePdf(søknadMedFiltrerteBarn)
-        : await sendInnOvergangstønadSøknad(søknadMedFiltrerteBarn);
+      const kvittering = await sendInnOvergangstønadSøknad(
+        søknadMedFiltrerteBarn
+      );
 
       settinnsendingState({
         ...innsendingState,

--- a/src/skolepenger/steg/7-dokumentasjon/SendSkolepengerSøknad.tsx
+++ b/src/skolepenger/steg/7-dokumentasjon/SendSkolepengerSøknad.tsx
@@ -11,7 +11,6 @@ import {
   mapBarnTilEntenIdentEllerFødselsdato,
   mapBarnUtenBarnepass,
   sendInnSkolepengerSøknad,
-  sendInnSkolepengerSøknadFamiliePdf,
 } from '../../../innsending/api';
 import {
   hentForrigeRoute,
@@ -31,8 +30,6 @@ import { ESkjemanavn, skjemanavnIdMapping } from '../../../utils/skjemanavn';
 import { Link, useNavigate } from 'react-router-dom';
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
 import { validerSøkerBosattINorgeSisteFemÅr } from '../../../helpers/steg/omdeg';
-import { useToggles } from '../../../context/TogglesContext';
-import { ToggleName } from '../../../models/søknad/toggles';
 import { useSpråkContext } from '../../../context/SpråkContext';
 
 interface Innsending {
@@ -42,7 +39,6 @@ interface Innsending {
 }
 
 const SendSøknadKnapper: FC = () => {
-  const { toggles } = useToggles();
   const { søknad, settSøknad } = useSkolepengerSøknad();
   const location = useLocation();
   const navigate = useNavigate();
@@ -60,11 +56,7 @@ const SendSøknadKnapper: FC = () => {
 
   const sendInnSøknad = async (søknadMedFiltrerteBarn: ISøknad) => {
     try {
-      const brukModernisertFlyt = toggles[ToggleName.visNyInnsendingsknapp];
-
-      const kvittering = brukModernisertFlyt
-        ? await sendInnSkolepengerSøknadFamiliePdf(søknadMedFiltrerteBarn)
-        : await sendInnSkolepengerSøknad(søknadMedFiltrerteBarn);
+      const kvittering = await sendInnSkolepengerSøknad(søknadMedFiltrerteBarn);
 
       settinnsendingState({
         ...innsendingState,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24467)

- Fjernet feature-toggle for styring av om man skal sende inn søknad via ny vs. gammel flyt
- Fjernet gamle endepunkt