### PR TITLE
Skille barnetilsyn fra generell løsning

### DIFF
--- a/src/barnetilsyn/DokumentasjonsConfig.test.ts
+++ b/src/barnetilsyn/DokumentasjonsConfig.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest';
+import { DokumentasjonsConfig } from './DokumentasjonsConfig';
+import {
+  AdresseopplysningerDokumentasjon,
+  AktivitetDokumentasjon,
+  BarnasBostedDokumentasjon,
+  BarnDokumentasjon,
+  BarnetilsynDokumentasjon,
+  BosituasjonDokumentasjon,
+  IDokumentasjon,
+  OmDegDokumentasjon,
+  SituasjonDokumentasjon,
+} from '../models/steg/dokumentasjon';
+
+describe('validerer dokumentasjonsconfig', () => {
+  test('Skal ha like mange keys i dokumentasjonsconfig som vi har i enums', () => {
+    const antallKeysIDokumentasjonsconfig =
+      Object.keys(DokumentasjonsConfig).length;
+
+    const alleEnums: number = [
+      Object.keys(SituasjonDokumentasjon).length,
+      Object.keys(BosituasjonDokumentasjon).length,
+      Object.keys(BarnetilsynDokumentasjon).length,
+      Object.keys(AktivitetDokumentasjon).length,
+      Object.keys(BarnasBostedDokumentasjon).length,
+      Object.keys(BarnDokumentasjon).length,
+      Object.keys(OmDegDokumentasjon).length,
+      Object.keys(AdresseopplysningerDokumentasjon).length,
+    ].reduce((last: number, current: number) => {
+      return last + current;
+    }, 0);
+
+    //DokumentasjonsConfig inneholder to innslag av Samværsavtale, derfor har den ett innslag ekstra
+    expect(antallKeysIDokumentasjonsconfig).toBe(alleEnums + 1);
+  });
+
+  test('Kun id SAMVÆRSAVTALE skal ha to innslag i DokumentasjonsConfig. Disse skal ha samme tittel og beskrivelse', () => {
+    const alleInnslagGruppertPåId: Map<string, IDokumentasjon[]> = groupBy(
+      Object.values(DokumentasjonsConfig),
+      'id'
+    );
+    const alleInnslagMedSammeId: IDokumentasjon[][] = Object.values(
+      alleInnslagGruppertPåId
+    ).filter((dokumentasjonListe) => dokumentasjonListe.length > 1);
+
+    expect(alleInnslagMedSammeId.length).toBe(1);
+    expect(alleInnslagMedSammeId[0].length).toBe(2);
+    expect(alleInnslagMedSammeId[0][0].id).toBe(
+      BarnasBostedDokumentasjon.SAMVÆRSAVTALE
+    );
+    expect(alleInnslagMedSammeId[0][0].tittel).toBe(
+      alleInnslagMedSammeId[0][1].tittel
+    );
+    expect(alleInnslagMedSammeId[0][0].beskrivelse).toBe(
+      alleInnslagMedSammeId[0][1].beskrivelse
+    );
+  });
+});
+
+// @ts-expect-error ukjent type
+const groupBy = (xs, key: string): Map<string, IDokumentasjon[]> => {
+  // @ts-expect-error ukjent type
+  return xs.reduce((rv, x) => {
+    (rv[x[key]] = rv[x[key]] || []).push(x);
+    return rv;
+  }, {});
+};

--- a/src/barnetilsyn/DokumentasjonsConfig.ts
+++ b/src/barnetilsyn/DokumentasjonsConfig.ts
@@ -1,0 +1,342 @@
+import {
+  AdresseopplysningerDokumentasjon,
+  AktivitetDokumentasjon,
+  BarnasBostedDokumentasjon,
+  BarnDokumentasjon,
+  BarnetilsynDokumentasjon,
+  BosituasjonDokumentasjon,
+  IDokumentasjon,
+  OmDegDokumentasjon,
+  SituasjonDokumentasjon,
+} from '../models/steg/dokumentasjon';
+import { EArbeidssøker } from '../models/steg/aktivitet/arbeidssøker';
+import { ESvar } from '../models/felles/spørsmålogsvar';
+import {
+  EAktivitet,
+  EArbeidssituasjon,
+} from '../models/steg/aktivitet/aktivitet';
+import { EUtdanning } from '../models/steg/aktivitet/utdanning';
+import {
+  DinSituasjonType,
+  ESagtOppEllerRedusertStilling,
+  ESituasjon,
+} from '../models/steg/dinsituasjon/meromsituasjon';
+import {
+  EArbeidsgiver,
+  EStilling,
+} from '../models/steg/aktivitet/arbeidsgiver';
+import { EBarn } from '../models/steg/barn';
+import {
+  EBarnepass,
+  ETypeBarnepassOrdning,
+  EÅrsakBarnepass,
+} from './models/barnepass';
+import { EBosituasjon, ESøkerDelerBolig } from '../models/steg/bosituasjon';
+import { EForelder } from '../models/steg/forelder';
+import {
+  EHarSkriftligSamværsavtale,
+  ESkalBarnetBoHosSøker,
+} from '../models/steg/barnasbosted';
+import {
+  EBegrunnelse,
+  ESivilstatusSøknadid,
+} from '../models/steg/omDeg/sivilstatus';
+import { EAdresseopplysninger } from '../models/steg/adresseopplysninger';
+
+type IDokumentasjonsConfig = {
+  [key in DokumentasjonsConfigKey]: IDokumentasjon;
+};
+
+type DokumentasjonsConfigKey =
+  | 'DokumentasjonIkkeVilligTilArbeid'
+  | 'DokumentasjonSyk'
+  | 'DokumentasjonOmVirksomhetenDuEtablerer'
+  | 'DokumentasjonUtgifterUtdanning'
+  | 'DokumentasjonUtdanning'
+  | 'DokumentasjonArbeidskontrakt'
+  | 'DokumentasjonLærling'
+  | 'Terminbekreftelse'
+  | 'FakturaFraBarnepassordning'
+  | 'AvtaleMedBarnepasser'
+  | 'DokumentasjonTrengerMerPassEnnJevnaldrede'
+  | 'DokumentasjonUtenomVanligArbeidstid'
+  | 'DokumentasjonMyeBortePgaJobb'
+  | 'DokumentasjonBorPåUlikeAdresser'
+  | 'DokumentasjonBarnBorHosDeg'
+  | 'SamværsavtaleMedKonkreteTidspunkter'
+  | 'SamværsavtaleUtenKonkreteTidspunkter'
+  | 'DokumentasjonSykdom'
+  | 'DokumentasjonSyktBarn'
+  | 'DokumentasjonBarnepassMangel'
+  | 'DokumentasjonBarnetilsynBehov'
+  | 'ArbeidsforholdOgOppsigelsesårsak'
+  | 'ArbeidsforholdOgRedusertArbeidstid'
+  | 'ErklæringSamlivsbrudd'
+  | 'DokumentasjonInngåttEkteskap'
+  | 'DokumentasjonUformeltSeparertEllerSkilt'
+  | 'MeldtAdresseendring'
+  | 'BekreftelseSeparasjonSøknad';
+
+export const DokumentasjonsConfig: IDokumentasjonsConfig = {
+  //AktivitetsConfig
+  DokumentasjonIkkeVilligTilArbeid: {
+    id: SituasjonDokumentasjon.IKKE_VILLIG_TIL_ARBEID,
+    spørsmålid: EArbeidssøker.villigTilÅTaImotTilbudOmArbeid,
+    svarid: ESvar.NEI,
+    label: '',
+    tittel: 'dokumentasjon.ikke.villig.til.arbeid.tittel',
+    beskrivelse: 'dokumentasjon.ikke.villig.til.arbeid.beskrivelse',
+    harSendtInn: false,
+  },
+  DokumentasjonSyk: {
+    id: AktivitetDokumentasjon.FOR_SYK_TIL_Å_JOBBE,
+    spørsmålid: EArbeidssituasjon.erDuIArbeid,
+    svarid: ESvar.NEI,
+    label: '',
+    tittel: 'dokumentasjon.syk-arbeid.tittel',
+    beskrivelse: 'dokumentasjon.syk-arbeid.beskrivelse',
+    harSendtInn: false,
+  },
+  DokumentasjonOmVirksomhetenDuEtablerer: {
+    id: AktivitetDokumentasjon.ETABLERER_VIRKSOMHET,
+    spørsmålid: EArbeidssituasjon.hvaErDinArbeidssituasjon,
+    svarid: EAktivitet.etablererEgenVirksomhet,
+    label: '',
+    tittel: 'dokumentasjon.etablererEgenVirksomhet.tittel',
+    beskrivelse: 'dokumentasjon.etablererEgenVirksomhet.beskrivelse',
+    harSendtInn: false,
+  },
+  DokumentasjonUtgifterUtdanning: {
+    id: AktivitetDokumentasjon.UTGIFTER_UTDANNING,
+    spørsmålid: EUtdanning.semesteravgift,
+    svarid: EAktivitet.tarUtdanning,
+    label: '',
+    tittel: 'utdanning.label.utgifter',
+    beskrivelse: 'utdanning.label.utgifter.dokumentasjon',
+    harSendtInn: false,
+  },
+  DokumentasjonUtdanning: {
+    id: AktivitetDokumentasjon.UTDANNING,
+    spørsmålid: EArbeidssituasjon.hvaErDinArbeidssituasjon,
+    svarid: EAktivitet.tarUtdanning,
+    label: '',
+    tittel: 'dokumentasjon.utdanning.tittel',
+    beskrivelse: 'dokumentasjon.utdanning.beskrivelse',
+    harSendtInn: false,
+  },
+  DokumentasjonArbeidskontrakt: {
+    id: SituasjonDokumentasjon.ARBEIDSKONTRAKT,
+    spørsmålid: ESituasjon.gjelderDetteDeg,
+    svarid: EAktivitet.harFåttJobbTilbud,
+    label: '',
+    tittel: 'dokumentasjon.arbeidskontrakt.tittel',
+    beskrivelse: 'dokumentasjon.arbeidskontrakt.beskrivelse',
+    harSendtInn: false,
+  },
+
+  //ArbeidsgiverConfig
+  DokumentasjonLærling: {
+    id: AktivitetDokumentasjon.LÆRLING,
+    spørsmålid: EArbeidsgiver.ansettelsesforhold,
+    svarid: EStilling.lærling,
+    label: '',
+    tittel: 'dokumentasjon.lærling.tittel',
+    harSendtInn: false,
+  },
+
+  //BarneConfig
+  Terminbekreftelse: {
+    id: BarnDokumentasjon.TERMINBEKREFTELSE,
+    spørsmålid: EBarn.født,
+    svarid: ESvar.NEI,
+    label: '',
+    tittel: 'dokumentasjon.terminbekreftelse.tittel',
+    harSendtInn: false,
+  },
+
+  //BarnepassConfig
+  FakturaFraBarnepassordning: {
+    id: BarnetilsynDokumentasjon.FAKTURA_BARNEPASSORDNING,
+    spørsmålid: EBarnepass.hvaSlagsBarnepassOrdning,
+    label: '',
+    svarid: ETypeBarnepassOrdning.barnehageOgLiknende,
+    tittel: 'dokumentasjon.barnehageOgLiknende.tittel',
+    beskrivelse: 'dokumentasjon.barnehageOgLiknende.beskrivelse',
+    harSendtInn: false,
+  },
+
+  AvtaleMedBarnepasser: {
+    id: BarnetilsynDokumentasjon.AVTALE_BARNEPASSER,
+    spørsmålid: EBarnepass.hvaSlagsBarnepassOrdning,
+    label: '',
+    svarid: ETypeBarnepassOrdning.privat,
+    tittel: 'dokumentasjon.privatBarnepass.tittel',
+    beskrivelse: 'dokumentasjon.privatBarnepass.beskrivelse',
+    harSendtInn: false,
+  },
+
+  DokumentasjonTrengerMerPassEnnJevnaldrede: {
+    id: BarnetilsynDokumentasjon.TRENGER_MER_PASS_ENN_JEVNALDREDE,
+    spørsmålid: EBarnepass.årsakBarnepass,
+    label: '',
+    svarid: EÅrsakBarnepass.trengerMerPassEnnJevnaldrede,
+    tittel: 'dokumentasjon.trengerMerPassEnnJevnaldrede.tittel',
+    beskrivelse: 'dokumentasjon.trengerMerPassEnnJevnaldrede.beskrivelse',
+    harSendtInn: false,
+  },
+
+  DokumentasjonUtenomVanligArbeidstid: {
+    id: BarnetilsynDokumentasjon.ARBEIDSTID,
+    spørsmålid: EBarnepass.årsakBarnepass,
+    label: '',
+    svarid: EÅrsakBarnepass.utenomVanligArbeidstid,
+    tittel: 'dokumentasjon.barnepassRoterendeArbeidstid.tittel',
+    harSendtInn: false,
+  },
+
+  DokumentasjonMyeBortePgaJobb: {
+    id: BarnetilsynDokumentasjon.ROTERENDE_ARBEIDSTID,
+    spørsmålid: EBarnepass.årsakBarnepass,
+    label: '',
+    svarid: EÅrsakBarnepass.myeBortePgaJobb,
+    tittel: 'dokumentasjon.barnepassArbeidstid.tittel',
+    harSendtInn: false,
+  },
+
+  //Bosituasjon
+  DokumentasjonBorPåUlikeAdresser: {
+    id: BosituasjonDokumentasjon.BOR_PÅ_ULIKE_ADRESSER,
+    spørsmålid: EBosituasjon.delerBoligMedAndreVoksne,
+    svarid: ESøkerDelerBolig.tidligereSamboerFortsattRegistrertPåAdresse,
+    label: '',
+    tittel: 'dokumentasjon.ulikeAdresser.tittel',
+    beskrivelse: 'dokumentasjon.ulikeAdresser.beskrivelse',
+    harSendtInn: false,
+  },
+
+  //Forelder
+  DokumentasjonBarnBorHosDeg: {
+    id: BarnasBostedDokumentasjon.BARN_BOR_HOS_SØKER,
+    spørsmålid: EForelder.skalBarnetBoHosSøker,
+    svarid: ESkalBarnetBoHosSøker.jaMenSamarbeiderIkke,
+    label: '',
+    tittel: 'dokumentasjon.barnBorHosSøker.tittel',
+    beskrivelse: 'dokumentasjon.barnBorHosSøker.beskrivelse',
+    harSendtInn: false,
+  },
+  SamværsavtaleMedKonkreteTidspunkter: {
+    id: BarnasBostedDokumentasjon.SAMVÆRSAVTALE,
+    spørsmålid: EForelder.harDereSkriftligSamværsavtale,
+    svarid: EHarSkriftligSamværsavtale.jaKonkreteTidspunkter,
+    label: '',
+    tittel: 'dokumentasjon.samværsavtale.tittel',
+    harSendtInn: false,
+  },
+  SamværsavtaleUtenKonkreteTidspunkter: {
+    id: BarnasBostedDokumentasjon.SAMVÆRSAVTALE,
+    spørsmålid: EForelder.harDereSkriftligSamværsavtale,
+    svarid: EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter,
+    label: '',
+    tittel: 'dokumentasjon.samværsavtale.tittel',
+    harSendtInn: false,
+  },
+
+  //Situasjon
+  DokumentasjonSykdom: {
+    id: SituasjonDokumentasjon.SYKDOM,
+    spørsmålid: ESituasjon.gjelderDetteDeg,
+    svarid: DinSituasjonType.erSyk,
+    label: '',
+    tittel: 'dokumentasjon.syk-dinSituasjon.tittel',
+    beskrivelse: 'dokumentasjon.syk-dinSituasjon.beskrivelse',
+    harSendtInn: false,
+  },
+  DokumentasjonSyktBarn: {
+    id: SituasjonDokumentasjon.SYKT_BARN,
+    spørsmålid: ESituasjon.gjelderDetteDeg,
+    svarid: DinSituasjonType.harSyktBarn,
+    label: '',
+    tittel: 'dokumentasjon.syktBarn.tittel',
+    beskrivelse: 'dokumentasjon.syktBarn.beskrivelse',
+    harSendtInn: false,
+  },
+  DokumentasjonBarnepassMangel: {
+    id: SituasjonDokumentasjon.BARNEPASS,
+    spørsmålid: ESituasjon.gjelderDetteDeg,
+    svarid: DinSituasjonType.harSøktBarnepassOgVenterEnnå,
+    label: '',
+    tittel: 'dokumentasjon.barnepass.tittel',
+    beskrivelse: 'dokumentasjon.barnepass.beskrivelse',
+    harSendtInn: false,
+  },
+  DokumentasjonBarnetilsynBehov: {
+    id: SituasjonDokumentasjon.BARNETILSYN_BEHOV,
+    spørsmålid: ESituasjon.gjelderDetteDeg,
+    svarid: DinSituasjonType.harBarnMedSærligeBehov,
+    label: '',
+    tittel: 'dokumentasjon.barnetilsynsbehov.tittel',
+    beskrivelse: 'dokumentasjon.barnetilsynsbehov.beskrivelse',
+    harSendtInn: false,
+  },
+  ArbeidsforholdOgOppsigelsesårsak: {
+    id: SituasjonDokumentasjon.ARBEIDSFORHOLD_OPPSIGELSE,
+    spørsmålid: ESituasjon.sagtOppEllerRedusertStilling,
+    svarid: ESagtOppEllerRedusertStilling.sagtOpp,
+    label: '',
+    tittel: 'dokumentasjon.arbeidsforhold-oppsigelse.tittel',
+    harSendtInn: false,
+  },
+  ArbeidsforholdOgRedusertArbeidstid: {
+    id: SituasjonDokumentasjon.ARBEIDSFORHOLD_REDUSERT_ARBEIDSTID,
+    spørsmålid: ESituasjon.sagtOppEllerRedusertStilling,
+    svarid: ESagtOppEllerRedusertStilling.redusertStilling,
+    label: '',
+    tittel: 'dokumentasjon.arbeidsforhold-redusert.tittel',
+    harSendtInn: false,
+  },
+
+  //Sivilstatus
+  ErklæringSamlivsbrudd: {
+    id: OmDegDokumentasjon.SAMLIVSBRUDD,
+    spørsmålid: ESivilstatusSøknadid.årsakEnslig,
+    svarid: EBegrunnelse.samlivsbruddForeldre,
+    label: '',
+    tittel: 'dokumentasjon.begrunnelse.tittel',
+    beskrivelse: 'dokumentasjon.begrunnelse.beskrivelse',
+    harSendtInn: false,
+  },
+  DokumentasjonInngåttEkteskap: {
+    id: OmDegDokumentasjon.INNGÅTT_EKTESKAP,
+    spørsmålid: ESivilstatusSøknadid.erUformeltGift,
+    svarid: ESvar.JA,
+    label: '',
+    tittel: 'dokumentasjon.inngåttEkteskap.tittel',
+    harSendtInn: false,
+  },
+  DokumentasjonUformeltSeparertEllerSkilt: {
+    id: OmDegDokumentasjon.UFORMELL_SEPARASJON_ELLER_SKILSMISSE,
+    spørsmålid: ESivilstatusSøknadid.erUformeltSeparertEllerSkilt,
+    svarid: ESvar.JA,
+    label: '',
+    tittel: 'dokumentasjon.separasjonEllerSkilsmisse.tittel',
+    harSendtInn: false,
+  },
+  BekreftelseSeparasjonSøknad: {
+    id: OmDegDokumentasjon.SEPARASJON_ELLER_SKILSMISSE,
+    spørsmålid: ESivilstatusSøknadid.harSøktSeparasjon,
+    svarid: ESvar.JA,
+    label: '',
+    tittel: 'dokumentasjon.søktSeparasjon.tittel',
+    beskrivelse: 'dokumentasjon.søktSeparasjon.beskrivelse',
+    harSendtInn: false,
+  },
+  MeldtAdresseendring: {
+    id: AdresseopplysningerDokumentasjon.MELDT_ADRESSEENDRING,
+    spørsmålid: EAdresseopplysninger.harMeldtAdresseendring,
+    svarid: ESvar.JA,
+    label: '',
+    tittel: 'dokumentasjon.meldtAdresseendring.tittel',
+    beskrivelse: 'dokumentasjon.meldtAdresseendring.beskrivelse',
+    harSendtInn: false,
+  },
+};

--- a/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
@@ -123,7 +123,6 @@ const OmDeg: FC = () => {
           sivilstatus={søknad.sivilstatus}
           settSivilstatus={settSivilstatus}
           settDokumentasjonsbehov={settDokumentasjonsbehov}
-          settMedlemskap={settMedlemskap}
         />
 
         <Show

--- a/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
@@ -8,10 +8,7 @@ import {
 } from '../../../helpers/steg/omdeg';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 import { IMedlemskap } from '../../../models/steg/omDeg/medlemskap';
-import Medlemskap from '../../../søknad/steg/1-omdeg/medlemskap/Medlemskap';
-import Personopplysninger from '../../../søknad/steg/1-omdeg/personopplysninger/Personopplysninger';
 import { ISpørsmålBooleanFelt } from '../../../models/søknad/søknadsfelter';
-import Sivilstatus from '../../../søknad/steg/1-omdeg/sivilstatus/Sivilstatus';
 import { ISivilstatus } from '../../../models/steg/omDeg/sivilstatus';
 import Side, { ESide } from '../../../components/side/Side';
 import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
@@ -23,6 +20,9 @@ import { useMount } from '../../../utils/hooks';
 import { ISøknad } from '../../models/søknad';
 import { kommerFraOppsummeringen } from '../../../utils/locationState';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import Personopplysninger from './personopplysninger/Personopplysninger';
+import Sivilstatus from './sivilstatus/Sivilstatus';
+import Medlemskap from './medlemskap/Medlemskap';
 
 const OmDeg: FC = () => {
   useMount(() => logSidevisningBarnetilsyn('OmDeg'));

--- a/src/barnetilsyn/steg/1-omdeg/medlemskap/Medlemskap.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/medlemskap/Medlemskap.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import {
+  ESvar,
+  ISpørsmål,
+  ISvar,
+} from '../../../../models/felles/spørsmålogsvar';
+import {
+  bosattINorgeDeSisteFemÅr,
+  hentLand,
+  oppholderSegINorge,
+  søkersOppholdsland,
+} from './MedlemskapConfig';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import JaNeiSpørsmål from '../../../../components/spørsmål/JaNeiSpørsmål';
+import PeriodeBoddIUtlandet from './PeriodeBoddIUtlandet';
+import SeksjonGruppe from '../../../../components/gruppe/SeksjonGruppe';
+import {
+  EMedlemskap,
+  IMedlemskap,
+} from '../../../../models/steg/omDeg/medlemskap';
+import { hentBooleanFraValgtSvar } from '../../../../utils/spørsmålogsvar';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import SelectSpørsmål from '../../../../components/spørsmål/SelectSpørsmål';
+import { useSpråkContext } from '../../../../context/SpråkContext';
+
+interface Props {
+  medlemskap: IMedlemskap;
+  settMedlemskap: (medlemskap: IMedlemskap) => void;
+}
+const Medlemskap = ({ medlemskap, settMedlemskap }: Props) => {
+  const intl = useLokalIntlContext();
+  const {
+    søkerOppholderSegINorge,
+    oppholdsland: oppholdsland,
+    søkerBosattINorgeSisteTreÅr,
+  } = medlemskap;
+
+  const oppholderSegINorgeConfig = oppholderSegINorge(intl);
+
+  const [locale] = useSpråkContext();
+  const land = hentLand(locale);
+  const oppholdslandConfig = søkersOppholdsland(land);
+
+  const bosattINorgeDeSisteTreÅrConfig = bosattINorgeDeSisteFemÅr(intl);
+
+  const settMedlemskapBooleanFelt = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
+    const svar: boolean = hentBooleanFraValgtSvar(valgtSvar);
+
+    if (
+      spørsmål.søknadid === EMedlemskap.søkerOppholderSegINorge &&
+      valgtSvar.id === ESvar.JA &&
+      medlemskap.oppholdsland
+    ) {
+      delete medlemskap.oppholdsland;
+    }
+
+    if (
+      spørsmål.søknadid === EMedlemskap.søkerBosattINorgeSisteTreÅr &&
+      valgtSvar.id === ESvar.JA &&
+      medlemskap.perioderBoddIUtlandet
+    ) {
+      delete medlemskap.perioderBoddIUtlandet;
+    }
+
+    settMedlemskap({
+      ...medlemskap,
+      [spørsmål.søknadid]: {
+        label: intl.formatMessage({ id: spørsmål.tekstid }),
+        verdi: svar,
+      },
+    });
+  };
+
+  const settOppholdsland = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
+    settMedlemskap({
+      ...medlemskap,
+      oppholdsland: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: valgtSvar.id,
+        label: intl.formatMessage({ id: spørsmål.tekstid }),
+        verdi: valgtSvar.svar_tekst,
+      },
+    });
+  };
+
+  const hentValgtSvar = (spørsmål: ISpørsmål, medlemskap: IMedlemskap) => {
+    for (const [key, value] of Object.entries(medlemskap)) {
+      if (key === spørsmål.søknadid && value !== undefined && value !== null) {
+        return value.verdi;
+      }
+    }
+  };
+
+  const valgtSvarOppholderSegINorge = hentValgtSvar(
+    oppholderSegINorgeConfig,
+    medlemskap
+  );
+
+  return (
+    <SeksjonGruppe aria-live="polite">
+      <KomponentGruppe key={oppholderSegINorgeConfig.søknadid}>
+        <JaNeiSpørsmål
+          spørsmål={oppholderSegINorgeConfig}
+          valgtSvar={valgtSvarOppholderSegINorge}
+          onChange={settMedlemskapBooleanFelt}
+        />
+      </KomponentGruppe>
+
+      {søkerOppholderSegINorge?.verdi === false && (
+        <KomponentGruppe>
+          <SelectSpørsmål
+            spørsmål={oppholdslandConfig}
+            valgtSvarId={medlemskap.oppholdsland?.svarid}
+            settSpørsmålOgSvar={settOppholdsland}
+          />
+        </KomponentGruppe>
+      )}
+
+      {(søkerOppholderSegINorge?.verdi === true ||
+        (søkerOppholderSegINorge?.verdi === false &&
+          // eslint-disable-next-line no-prototype-builtins
+          oppholdsland?.hasOwnProperty('verdi'))) && (
+        <>
+          <KomponentGruppe key={bosattINorgeDeSisteTreÅrConfig.søknadid}>
+            <JaNeiSpørsmål
+              spørsmål={bosattINorgeDeSisteTreÅrConfig}
+              valgtSvar={hentValgtSvar(
+                bosattINorgeDeSisteTreÅrConfig,
+                medlemskap
+              )}
+              onChange={settMedlemskapBooleanFelt}
+            />
+          </KomponentGruppe>
+
+          {søkerBosattINorgeSisteTreÅr?.verdi === false && (
+            <PeriodeBoddIUtlandet
+              medlemskap={medlemskap}
+              settMedlemskap={settMedlemskap}
+              land={land}
+            />
+          )}
+        </>
+      )}
+    </SeksjonGruppe>
+  );
+};
+
+export default Medlemskap;

--- a/src/barnetilsyn/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/medlemskap/MedlemskapConfig.tsx
@@ -1,0 +1,59 @@
+import { ISpørsmål } from '../../../../models/felles/spørsmålogsvar';
+import { JaNeiSvar } from '../../../../helpers/svar';
+import {
+  EMedlemskap,
+  ILandMedKode,
+} from '../../../../models/steg/omDeg/medlemskap';
+import { LocaleType, LokalIntlShape } from '../../../../language/typer';
+import CountryData, { Countries, CountryFilter } from '@navikt/land-verktoy';
+
+export const oppholderSegINorge = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EMedlemskap.søkerOppholderSegINorge,
+  tekstid: 'medlemskap.spm.opphold',
+  flersvar: false,
+
+  svaralternativer: JaNeiSvar(intl),
+});
+
+export const søkersOppholdsland = (land: ILandMedKode[]): ISpørsmål => ({
+  søknadid: EMedlemskap.oppholdsland,
+  tekstid: 'medlemskap.spm.oppholdsland',
+  flersvar: false,
+  svaralternativer: land,
+});
+
+export const bosattINorgeDeSisteFemÅr = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EMedlemskap.søkerBosattINorgeSisteTreÅr,
+  tekstid: 'medlemskap.spm.bosatt',
+  flersvar: false,
+
+  svaralternativer: JaNeiSvar(intl),
+});
+
+export const utenlandsoppholdLand = (land: ILandMedKode[]): ISpørsmål => ({
+  søknadid: EMedlemskap.utenlandsoppholdLand,
+  tekstid: 'medlemskap.periodeBoddIUtlandet.land',
+  flersvar: false,
+  svaralternativer: land,
+});
+
+export const hentLand = (språk: LocaleType): ILandMedKode[] => {
+  const landFilter = CountryFilter.STANDARD({});
+  const filtrertLandliste: Countries =
+    CountryData.getCountryInstance(språk).filterByValueOnArray(landFilter);
+  const eøsLand = hentEØSLand(språk);
+  return filtrertLandliste
+    .map((land: { alpha3: string; label: string }) => {
+      return {
+        id: land.alpha3,
+        svar_tekst: land.label,
+        erEøsland: eøsLand.some((eøs) => eøs.alpha3 === land.alpha3),
+      };
+    })
+    .sort((a, b) => a.svar_tekst.localeCompare(b.svar_tekst));
+};
+
+export const hentEØSLand = (språk: LocaleType): Countries => {
+  const landFilter = CountryFilter.EEA({});
+  return CountryData.getCountryInstance(språk).filterByValueOnArray(landFilter);
+};

--- a/src/barnetilsyn/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
@@ -1,0 +1,98 @@
+import { FC, useEffect, useState } from 'react';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import Utenlandsopphold from './Utenlandsopphold';
+
+import { hentTekst } from '../../../../utils/søknad';
+import { hentUid } from '../../../../utils/autentiseringogvalidering/uuid';
+import {
+  ILandMedKode,
+  IMedlemskap,
+  IUtenlandsopphold,
+} from '../../../../models/steg/omDeg/medlemskap';
+import { tomPeriode } from '../../../../helpers/tommeSøknadsfelter';
+import LeggTilKnapp from '../../../../components/knapper/LeggTilKnapp';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { Label } from '@navikt/ds-react';
+
+const PeriodeBoddIUtlandet: FC<{
+  medlemskap: IMedlemskap;
+  settMedlemskap: (medlemskap: IMedlemskap) => void;
+  land: ILandMedKode[];
+}> = ({ medlemskap, settMedlemskap, land }) => {
+  const intl = useLokalIntlContext();
+  const tomtUtenlandsopphold: IUtenlandsopphold = {
+    id: hentUid(),
+    periode: tomPeriode,
+    erEøsLand: true,
+    begrunnelse: {
+      label: hentTekst('medlemskap.periodeBoddIUtlandet.begrunnelse', intl),
+      verdi: '',
+    },
+  };
+  const [perioderBoddIUtlandet, settPerioderBoddIUtlandet] = useState<
+    IUtenlandsopphold[]
+  >(
+    medlemskap?.perioderBoddIUtlandet &&
+      medlemskap.perioderBoddIUtlandet.length > 0
+      ? medlemskap.perioderBoddIUtlandet
+      : [tomtUtenlandsopphold]
+  );
+
+  const erForrigePeriodeFyltUt: boolean = perioderBoddIUtlandet.every(
+    (utenlandsopphold) => utenlandsopphold.begrunnelse.verdi !== ''
+  );
+
+  useEffect(() => {
+    settMedlemskap({
+      ...medlemskap,
+      perioderBoddIUtlandet: perioderBoddIUtlandet,
+    });
+    // eslint-disable-next-line
+  }, [perioderBoddIUtlandet]);
+
+  const leggTilUtenlandsperiode = () => {
+    const alleUtenlandsopphold = perioderBoddIUtlandet;
+    alleUtenlandsopphold && alleUtenlandsopphold.push(tomtUtenlandsopphold);
+    alleUtenlandsopphold &&
+      settMedlemskap({
+        ...medlemskap,
+        perioderBoddIUtlandet: alleUtenlandsopphold,
+      });
+  };
+
+  return (
+    <>
+      {perioderBoddIUtlandet?.map((periode, index) => {
+        return (
+          <KomponentGruppe key={periode.id}>
+            <Utenlandsopphold
+              settPeriodeBoddIUtlandet={settPerioderBoddIUtlandet}
+              perioderBoddIUtlandet={perioderBoddIUtlandet}
+              utenlandsopphold={periode}
+              oppholdsnr={index}
+              land={land}
+            />
+          </KomponentGruppe>
+        );
+      })}
+
+      {erForrigePeriodeFyltUt && (
+        <KomponentGruppe>
+          <FeltGruppe>
+            <Label as="p">
+              <LocaleTekst
+                tekst={'medlemskap.periodeBoddIUtlandet.flereutenlandsopphold'}
+              />
+            </Label>
+            <LeggTilKnapp onClick={() => leggTilUtenlandsperiode()}>
+              <LocaleTekst tekst={'medlemskap.periodeBoddIUtlandet.knapp'} />
+            </LeggTilKnapp>
+          </FeltGruppe>
+        </KomponentGruppe>
+      )}
+    </>
+  );
+};
+export default PeriodeBoddIUtlandet;

--- a/src/barnetilsyn/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -1,0 +1,241 @@
+import React, { FC } from 'react';
+import { SlettKnapp } from '../../../../components/knapper/SlettKnapp';
+import { hentTittelMedNr } from '../../../../language/utils';
+import PeriodeDatovelgere from '../../../../components/dato/PeriodeDatovelger';
+import { hentTekst, hentTekstMedVariabel } from '../../../../utils/søknad';
+import {
+  ILandMedKode,
+  IUtenlandsopphold,
+} from '../../../../models/steg/omDeg/medlemskap';
+import { erPeriodeDatoerValgt } from '../../../../helpers/steg/omdeg';
+import { EPeriode } from '../../../../models/felles/periode';
+import styled from 'styled-components';
+import { DatoBegrensning } from '../../../../components/dato/Datovelger';
+import { erPeriodeGyldigOgInnaforBegrensninger } from '../../../../components/dato/utils';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { Heading, HStack, Textarea } from '@navikt/ds-react';
+import SelectSpørsmål from '../../../../components/spørsmål/SelectSpørsmål';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import { utenlandsoppholdLand } from './MedlemskapConfig';
+import { TextFieldMedBredde } from '../../../../components/TextFieldMedBredde';
+import EøsIdent from '../../../../components/EøsIdent';
+import { stringHarVerdiOgErIkkeTom } from '../../../../utils/typer';
+
+const StyledTextarea = styled(Textarea)`
+  width: 100%;
+`;
+
+const StyledPeriodeDatovelgere = styled(PeriodeDatovelgere)`
+  padding-bottom: 0;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+interface Props {
+  perioderBoddIUtlandet: IUtenlandsopphold[];
+  settPeriodeBoddIUtlandet: (periodeBoddIUtlandet: IUtenlandsopphold[]) => void;
+  utenlandsopphold: IUtenlandsopphold;
+  oppholdsnr: number;
+  land: ILandMedKode[];
+}
+const Utenlandsopphold: FC<Props> = ({
+  perioderBoddIUtlandet,
+  settPeriodeBoddIUtlandet,
+  oppholdsnr,
+  utenlandsopphold,
+  land,
+}) => {
+  const { periode, begrunnelse, adresseEøsLand } = utenlandsopphold;
+  const intl = useLokalIntlContext();
+  const periodeTittel = hentTittelMedNr(
+    perioderBoddIUtlandet!,
+    oppholdsnr,
+    hentTekst('medlemskap.periodeBoddIUtlandet.utenlandsopphold', intl)
+  );
+  const begrunnelseTekst = hentTekstMedVariabel(
+    'medlemskap.periodeBoddIUtlandet.begrunnelse',
+    intl,
+    { 0: utenlandsopphold.land?.verdi || '' }
+  );
+  const sisteAdresseTekst = hentTekstMedVariabel(
+    'medlemskap.periodeBoddIUtlandet.sisteAdresse',
+    intl,
+    { 0: utenlandsopphold.land?.verdi || '' }
+  );
+
+  const landConfig = utenlandsoppholdLand(land);
+
+  const fjernUtenlandsperiode = () => {
+    if (perioderBoddIUtlandet && perioderBoddIUtlandet.length > 1) {
+      const utenlandsopphold = perioderBoddIUtlandet?.filter(
+        (periode, index) => index !== oppholdsnr
+      );
+      settPeriodeBoddIUtlandet(utenlandsopphold);
+    }
+  };
+
+  const settPeriode = (objektnøkkel: EPeriode, date?: string): void => {
+    const oppdatertUtenlandsopphold = {
+      ...utenlandsopphold,
+      periode: {
+        ...periode,
+        label: hentTekst('medlemskap.periodeBoddIUtlandet', intl),
+        [objektnøkkel]: {
+          label: hentTekst('periode.' + objektnøkkel, intl),
+          verdi: date ? date : '',
+        },
+      },
+    };
+
+    oppdaterUtenlandsopphold(oppdatertUtenlandsopphold);
+  };
+
+  const settLand = (spørsmål: ISpørsmål, svar: ISvar) => {
+    const oppdatertUtenlandsopphold = {
+      ...utenlandsopphold,
+      land: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: svar.id,
+        label: intl.formatMessage({ id: spørsmål.tekstid }),
+        verdi: svar.svar_tekst,
+      },
+      erEøsLand: land.find((l) => l.id === svar.id)?.erEøsland || false,
+      personidentEøsLand: { label: '', verdi: '' },
+      adresseEøsLand: { label: '', verdi: '' },
+      kanIkkeOppgiPersonident: undefined,
+    };
+
+    oppdaterUtenlandsopphold(oppdatertUtenlandsopphold);
+  };
+
+  const settFeltNavn = (
+    e:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+    feltnavn: string,
+    label: string
+  ): void => {
+    const oppdatertUtenlandsopphold: IUtenlandsopphold = {
+      ...utenlandsopphold,
+      [feltnavn]: { label: label, verdi: e.target.value },
+    };
+    oppdaterUtenlandsopphold(oppdatertUtenlandsopphold);
+  };
+
+  const oppdaterUtenlandsopphold = (
+    oppdatertUtenlandsopphold: IUtenlandsopphold
+  ) => {
+    const perioderMedUtenlandskPersonId = perioderBoddIUtlandet.map(
+      (utenlandsopphold, index) =>
+        index === oppholdsnr ? oppdatertUtenlandsopphold : utenlandsopphold
+    );
+    settPeriodeBoddIUtlandet(perioderMedUtenlandskPersonId);
+  };
+
+  const skalVisePersonidentTekstfelt = (
+    utenlandsopphold: IUtenlandsopphold
+  ) => {
+    return (
+      utenlandsopphold.land &&
+      utenlandsopphold.erEøsLand &&
+      stringHarVerdiOgErIkkeTom(utenlandsopphold.begrunnelse.verdi)
+    );
+  };
+
+  const skalViseAdresseTekstfelt = (utenlandsopphold: IUtenlandsopphold) => {
+    return (
+      skalVisePersonidentTekstfelt(utenlandsopphold) &&
+      (stringHarVerdiOgErIkkeTom(
+        utenlandsopphold.personidentEøsLand?.verdi?.trim()
+      ) ||
+        utenlandsopphold.kanIkkeOppgiPersonident)
+    );
+  };
+
+  const skalViseSlettKnapp = perioderBoddIUtlandet?.length > 1;
+
+  return (
+    <Container aria-live="polite">
+      <HStack justify="space-between" align="center">
+        <Heading size="small" level="3" className={'tittel'}>
+          {periodeTittel}
+        </Heading>
+        {skalViseSlettKnapp && (
+          <SlettKnapp
+            onClick={() => fjernUtenlandsperiode()}
+            tekstid={'medlemskap.periodeBoddIUtlandet.slett'}
+          />
+        )}
+      </HStack>
+
+      <StyledPeriodeDatovelgere
+        className={'periodegruppe'}
+        settDato={settPeriode}
+        periode={utenlandsopphold.periode}
+        tekst={hentTekst('medlemskap.periodeBoddIUtlandet', intl)}
+        datobegrensning={DatoBegrensning.TidligereDatoer}
+      />
+      <SelectSpørsmål
+        spørsmål={landConfig}
+        settSpørsmålOgSvar={settLand}
+        valgtSvarId={perioderBoddIUtlandet[oppholdsnr].land?.svarid}
+        skalLogges={false}
+      />
+      {erPeriodeDatoerValgt(utenlandsopphold.periode) &&
+        erPeriodeGyldigOgInnaforBegrensninger(
+          utenlandsopphold.periode,
+          DatoBegrensning.TidligereDatoer
+        ) &&
+        // eslint-disable-next-line no-prototype-builtins
+        utenlandsopphold.land?.hasOwnProperty('verdi') && (
+          <StyledTextarea
+            label={begrunnelseTekst}
+            placeholder={'...'}
+            value={begrunnelse.verdi}
+            maxLength={1000}
+            autoComplete={'off'}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+              if (e.target.value.length <= 1000) {
+                settFeltNavn(e, 'begrunnelse', begrunnelseTekst);
+              }
+            }}
+          />
+        )}
+
+      {utenlandsopphold.land &&
+        skalVisePersonidentTekstfelt(utenlandsopphold) && (
+          <EøsIdent
+            halvåpenTekstid={hentTekst(
+              'medlemskap.hjelpetekst-åpne.begrunnelse',
+              intl
+            )}
+            åpneTekstid={hentTekst(
+              'medlemskap.hjelpetekst-innhold.begrunnelse',
+              intl
+            )}
+            utenlandsopphold={utenlandsopphold}
+            settUtenlandsopphold={(oppdatertUtenlandsopphold) =>
+              oppdaterUtenlandsopphold(oppdatertUtenlandsopphold)
+            }
+          />
+        )}
+      {utenlandsopphold.land && skalViseAdresseTekstfelt(utenlandsopphold) && (
+        <TextFieldMedBredde
+          className={'inputfelt-tekst'}
+          key={'navn'}
+          label={sisteAdresseTekst}
+          type="text"
+          bredde={'L'}
+          onChange={(e) => settFeltNavn(e, 'adresseEøsLand', sisteAdresseTekst)}
+          value={adresseEøsLand?.verdi}
+        />
+      )}
+    </Container>
+  );
+};
+
+export default Utenlandsopphold;

--- a/src/barnetilsyn/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import JaNeiSpørsmål from '../../../../components/spørsmål/JaNeiSpørsmål';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import SeksjonGruppe from '../../../../components/gruppe/SeksjonGruppe';
+import SøkerBorIkkePåAdresse from './SøkerBorIkkePåAdresse';
+import {
+  borDuPåDenneAdressen,
+  harMeldtAdresseendringSpørsmål,
+} from './PersonopplysningerConfig';
+import { hentBooleanFraValgtSvar } from '../../../../utils/spørsmålogsvar';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import { hentSivilstatus } from '../../../../helpers/steg/omdeg';
+import { ISøker } from '../../../../models/søknad/person';
+import { ISpørsmålBooleanFelt } from '../../../../models/søknad/søknadsfelter';
+import { Stønadstype } from '../../../../models/søknad/stønadstyper';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { Alert, BodyShort, Label } from '@navikt/ds-react';
+import AlertStripeDokumentasjon from '../../../../components/AlertstripeDokumentasjon';
+import { hentTekst } from '../../../../utils/søknad';
+
+interface Props {
+  søker: ISøker;
+  settDokumentasjonsbehov: (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar,
+    erHuketAv?: boolean
+  ) => void;
+  søkerBorPåRegistrertAdresse?: ISpørsmålBooleanFelt;
+  settSøkerBorPåRegistrertAdresse: (
+    søkerBorPåRegistrertAdresse: ISpørsmålBooleanFelt
+  ) => void;
+  harMeldtAdresseendring?: ISpørsmålBooleanFelt;
+  settHarMeldtAdresseendring: (
+    harMeldtAdresseendring: ISpørsmålBooleanFelt
+  ) => void;
+  stønadstype: Stønadstype;
+}
+
+const Personopplysninger: React.FC<Props> = ({
+  søker,
+  settDokumentasjonsbehov,
+  søkerBorPåRegistrertAdresse,
+  settSøkerBorPåRegistrertAdresse,
+  harMeldtAdresseendring,
+  settHarMeldtAdresseendring,
+  stønadstype,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const settPersonopplysningerFelt = (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar
+  ) => {
+    const svar: boolean = hentBooleanFraValgtSvar(valgtSvar);
+    settSøkerBorPåRegistrertAdresse({
+      spørsmålid: spørsmål.søknadid,
+      svarid: valgtSvar.id,
+      label: hentTekst(spørsmål.tekstid, intl),
+      verdi: svar,
+    });
+  };
+
+  const settMeldtAdresseendring = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
+    const svar: boolean = hentBooleanFraValgtSvar(valgtSvar);
+    settHarMeldtAdresseendring({
+      spørsmålid: spørsmål.søknadid,
+      svarid: valgtSvar.id,
+      label: hentTekst(spørsmål.tekstid, intl),
+      verdi: svar,
+    });
+    settDokumentasjonsbehov(spørsmål, valgtSvar);
+  };
+  return (
+    <SeksjonGruppe aria-live={'polite'}>
+      <KomponentGruppe>
+        <FeltGruppe>
+          <Alert size="small" variant="info" inline>
+            <LocaleTekst tekst={'personopplysninger.alert.infohentet'} />
+          </Alert>
+        </FeltGruppe>
+
+        <FeltGruppe>
+          <Label as="p">
+            <LocaleTekst tekst={'person.ident.visning'} />
+          </Label>
+          <BodyShort>{søker.fnr}</BodyShort>
+        </FeltGruppe>
+
+        <FeltGruppe>
+          <Label as="p">
+            <LocaleTekst tekst={'person.statsborgerskap'} />
+          </Label>
+          <BodyShort>{søker.statsborgerskap}</BodyShort>
+        </FeltGruppe>
+
+        <FeltGruppe>
+          <Label as="p">
+            <LocaleTekst tekst={'sivilstatus.tittel'} />
+          </Label>
+          <BodyShort>
+            <LocaleTekst tekst={hentSivilstatus(søker.sivilstand)} />
+          </BodyShort>
+        </FeltGruppe>
+
+        <FeltGruppe>
+          <Label as="p">
+            <LocaleTekst tekst={'person.adresse'} />
+          </Label>
+          <BodyShort>{søker.adresse.adresse}</BodyShort>
+          <BodyShort>
+            {søker.adresse.postnummer} {søker.adresse.poststed}
+          </BodyShort>
+        </FeltGruppe>
+      </KomponentGruppe>
+
+      {!søker?.erStrengtFortrolig && (
+        <>
+          <KomponentGruppe aria-live="polite">
+            <JaNeiSpørsmål
+              spørsmål={borDuPåDenneAdressen(intl)}
+              valgtSvar={søkerBorPåRegistrertAdresse?.verdi}
+              onChange={settPersonopplysningerFelt}
+            />
+          </KomponentGruppe>
+
+          {søkerBorPåRegistrertAdresse?.verdi === false && (
+            <KomponentGruppe>
+              <JaNeiSpørsmål
+                spørsmål={harMeldtAdresseendringSpørsmål(intl)}
+                valgtSvar={harMeldtAdresseendring?.verdi}
+                onChange={settMeldtAdresseendring}
+              />
+              {harMeldtAdresseendring?.verdi === true && (
+                <AlertStripeDokumentasjon>
+                  <LocaleTekst
+                    tekst={'personopplysninger.alert.meldtAdresseendring'}
+                  />
+                </AlertStripeDokumentasjon>
+              )}
+              {harMeldtAdresseendring?.verdi === false && (
+                <SøkerBorIkkePåAdresse stønadstype={stønadstype} />
+              )}
+            </KomponentGruppe>
+          )}
+        </>
+      )}
+    </SeksjonGruppe>
+  );
+};
+
+export default Personopplysninger;

--- a/src/barnetilsyn/steg/1-omdeg/personopplysninger/PersonopplysningerConfig.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/personopplysninger/PersonopplysningerConfig.tsx
@@ -1,0 +1,30 @@
+import { ISpørsmål } from '../../../../models/felles/spørsmålogsvar';
+import { JaNeiSvar, JaSvar, NeiSvar } from '../../../../helpers/svar';
+import { ESøknad } from '../../../../models/søknad/søknad';
+import { LokalIntlShape } from '../../../../language/typer';
+import { EAdresseopplysninger } from '../../../../models/steg/adresseopplysninger';
+import { DokumentasjonsConfig } from '../../../../søknad/DokumentasjonsConfig';
+
+export const borDuPåDenneAdressen = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: ESøknad.søkerBorPåRegistrertAdresse,
+  tekstid: 'personopplysninger.spm.riktigAdresse',
+  flersvar: false,
+  svaralternativer: JaNeiSvar(intl),
+});
+
+export const harMeldtAdresseendringSpørsmål = (
+  intl: LokalIntlShape
+): ISpørsmål => ({
+  søknadid: EAdresseopplysninger.harMeldtAdresseendring,
+  tekstid: 'personopplysninger.spm.meldtAdresseendring',
+  lesmer: undefined,
+  flersvar: false,
+  svaralternativer: [
+    {
+      ...JaSvar(intl),
+      alert_tekstid: '',
+      dokumentasjonsbehov: DokumentasjonsConfig.MeldtAdresseendring,
+    },
+    NeiSvar(intl),
+  ],
+});

--- a/src/barnetilsyn/steg/1-omdeg/personopplysninger/PersonopplysningerConfig.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/personopplysninger/PersonopplysningerConfig.tsx
@@ -3,7 +3,7 @@ import { JaNeiSvar, JaSvar, NeiSvar } from '../../../../helpers/svar';
 import { ESøknad } from '../../../../models/søknad/søknad';
 import { LokalIntlShape } from '../../../../language/typer';
 import { EAdresseopplysninger } from '../../../../models/steg/adresseopplysninger';
-import { DokumentasjonsConfig } from '../../../../søknad/DokumentasjonsConfig';
+import { DokumentasjonsConfig } from '../../../DokumentasjonsConfig';
 
 export const borDuPåDenneAdressen = (intl: LokalIntlShape): ISpørsmål => ({
   søknadid: ESøknad.søkerBorPåRegistrertAdresse,

--- a/src/barnetilsyn/steg/1-omdeg/personopplysninger/SøkerBorIkkePåAdresse.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/personopplysninger/SøkerBorIkkePåAdresse.tsx
@@ -1,0 +1,48 @@
+import { FC } from 'react';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import { Stønadstype } from '../../../../models/søknad/stønadstyper';
+import { Alert, BodyShort, Label } from '@navikt/ds-react';
+
+interface Props {
+  stønadstype: Stønadstype;
+}
+
+const lenkerPDFSøknad = {
+  [Stønadstype.overgangsstønad]:
+    'https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.01/dokumentinnsending',
+  [Stønadstype.barnetilsyn]:
+    'https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.02/dokumentinnsending',
+  [Stønadstype.skolepenger]:
+    'https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.04/dokumentinnsending',
+};
+
+const SøkerBorIkkePåAdresse: FC<Props> = ({ stønadstype }) => {
+  return (
+    <>
+      <KomponentGruppe>
+        <Alert size="small" variant="warning" inline>
+          <LocaleTekst tekst={'personopplysninger.alert.riktigAdresse'} />
+        </Alert>
+      </KomponentGruppe>
+      <KomponentGruppe>
+        <FeltGruppe>
+          <Label as="p">
+            <LocaleTekst tekst={'personopplysninger.info.endreAdresse'} />
+          </Label>
+        </FeltGruppe>
+        <FeltGruppe>
+          <BodyShort>
+            <LocaleTekst
+              tekst={'personopplysninger.lenke.pdfskjema'}
+              replaceArgument0={lenkerPDFSøknad[stønadstype]}
+            />
+          </BodyShort>
+        </FeltGruppe>
+      </KomponentGruppe>
+    </>
+  );
+};
+
+export default SøkerBorIkkePåAdresse;

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
@@ -1,0 +1,119 @@
+import React, { useContext } from 'react';
+import SeksjonGruppe from '../../../../components/gruppe/SeksjonGruppe';
+import SøkerErGift from './SøkerErGift';
+import { hentBooleanFraValgtSvar } from '../../../../utils/spørsmålogsvar';
+import { hentTekst } from '../../../../utils/søknad';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import { usePersonContext } from '../../../../context/PersonContext';
+import {
+  ESivilstatusSøknadid,
+  ISivilstatus,
+} from '../../../../models/steg/omDeg/sivilstatus';
+import SpørsmålGiftSeparertEllerSkiltIkkeRegistrert from './SpørsmålGiftSeparertEllerSkiltIkkeRegistrert';
+import {
+  erSøkerGift,
+  erSøkerUGiftSkiltSeparertEllerEnke,
+} from '../../../../utils/sivilstatus';
+import { IMedlemskap } from '../../../../models/steg/omDeg/medlemskap';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import ÅrsakEnslig from './begrunnelse/ÅrsakEnslig';
+import { erSivilstandSpørsmålBesvart } from '../../../../helpers/steg/omdeg';
+import { GjenbrukContext } from '../../../../context/GjenbrukContext';
+
+interface Props {
+  sivilstatus: ISivilstatus;
+  settSivilstatus: (sivilstatus: ISivilstatus) => void;
+  settMedlemskap: (medlemskap: IMedlemskap) => void;
+  settDokumentasjonsbehov: (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar,
+    erHuketAv?: boolean
+  ) => void;
+}
+
+const Sivilstatus: React.FC<Props> = ({
+  sivilstatus,
+  settSivilstatus,
+  settDokumentasjonsbehov,
+  settMedlemskap,
+}) => {
+  const intl = useLokalIntlContext();
+  const { person } = usePersonContext();
+  const sivilstand = person.søker.sivilstand;
+  const { erUformeltGift, datoFlyttetFraHverandre, datoSøktSeparasjon } =
+    sivilstatus;
+  const { skalGjenbrukeSøknad } = useContext(GjenbrukContext);
+
+  const gjenbrukerSøknadOgHarUbesvartSeparsjonsspørsmål = () =>
+    skalGjenbrukeSøknad && sivilstatus.harSøktSeparasjon === undefined;
+  const settSivilstatusFelt = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
+    const spørsmålLabel = hentTekst(spørsmål.tekstid, intl);
+    const svar: boolean = hentBooleanFraValgtSvar(valgtSvar);
+
+    const nySivilstatus = {
+      ...sivilstatus,
+      [spørsmål.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: valgtSvar.id,
+        label: spørsmålLabel,
+        verdi: svar,
+      },
+    };
+    if (
+      spørsmål.søknadid === ESivilstatusSøknadid.harSøktSeparasjon &&
+      !gjenbrukerSøknadOgHarUbesvartSeparsjonsspørsmål()
+    ) {
+      datoSøktSeparasjon && delete nySivilstatus.datoSøktSeparasjon;
+      datoFlyttetFraHverandre && delete nySivilstatus.datoFlyttetFraHverandre;
+    }
+
+    settSivilstatus(nySivilstatus);
+    settDokumentasjonsbehov(spørsmål, valgtSvar);
+  };
+
+  const settDato = (
+    date: string,
+    objektnøkkel: string,
+    tekstid: string
+  ): void => {
+    settSivilstatus({
+      ...sivilstatus,
+      [objektnøkkel]: {
+        label: intl.formatMessage({ id: tekstid }),
+        verdi: date,
+      },
+    });
+  };
+
+  return (
+    <SeksjonGruppe aria-live="polite">
+      {erSøkerGift(sivilstand) && (
+        <SøkerErGift
+          settJaNeiFelt={settSivilstatusFelt}
+          settDato={settDato}
+          sivilstatus={sivilstatus}
+        />
+      )}
+
+      {erSøkerUGiftSkiltSeparertEllerEnke(sivilstand) && (
+        <SpørsmålGiftSeparertEllerSkiltIkkeRegistrert
+          erUformeltGift={erUformeltGift}
+          settSivilstatusFelt={settSivilstatusFelt}
+          sivilstatus={sivilstatus}
+        />
+      )}
+
+      {erSivilstandSpørsmålBesvart(sivilstand, sivilstatus) && (
+        <ÅrsakEnslig
+          sivilstatus={sivilstatus}
+          settSivilstatus={settSivilstatus}
+          settDato={settDato}
+          settDokumentasjonsbehov={settDokumentasjonsbehov}
+          settMedlemskap={settMedlemskap}
+        />
+      )}
+    </SeksjonGruppe>
+  );
+};
+
+export default Sivilstatus;

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/Sivilstatus.tsx
@@ -14,7 +14,6 @@ import {
   erSøkerGift,
   erSøkerUGiftSkiltSeparertEllerEnke,
 } from '../../../../utils/sivilstatus';
-import { IMedlemskap } from '../../../../models/steg/omDeg/medlemskap';
 import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
 import ÅrsakEnslig from './begrunnelse/ÅrsakEnslig';
 import { erSivilstandSpørsmålBesvart } from '../../../../helpers/steg/omdeg';
@@ -23,7 +22,6 @@ import { GjenbrukContext } from '../../../../context/GjenbrukContext';
 interface Props {
   sivilstatus: ISivilstatus;
   settSivilstatus: (sivilstatus: ISivilstatus) => void;
-  settMedlemskap: (medlemskap: IMedlemskap) => void;
   settDokumentasjonsbehov: (
     spørsmål: ISpørsmål,
     valgtSvar: ISvar,
@@ -35,7 +33,6 @@ const Sivilstatus: React.FC<Props> = ({
   sivilstatus,
   settSivilstatus,
   settDokumentasjonsbehov,
-  settMedlemskap,
 }) => {
   const intl = useLokalIntlContext();
   const { person } = usePersonContext();
@@ -109,7 +106,6 @@ const Sivilstatus: React.FC<Props> = ({
           settSivilstatus={settSivilstatus}
           settDato={settDato}
           settDokumentasjonsbehov={settDokumentasjonsbehov}
-          settMedlemskap={settMedlemskap}
         />
       )}
     </SeksjonGruppe>

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/SivilstatusConfig.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/SivilstatusConfig.tsx
@@ -1,0 +1,106 @@
+import { IDokumentasjon } from '../../../../models/steg/dokumentasjon';
+import {
+  EBegrunnelse,
+  ESivilstatusSøknadid,
+} from '../../../../models/steg/omDeg/sivilstatus';
+import { ISpørsmål } from '../../../../models/felles/spørsmålogsvar';
+import { JaSvar, NeiSvar } from '../../../../helpers/svar';
+import { LokalIntlShape } from '../../../../language/typer';
+import { DokumentasjonsConfig } from '../../../../søknad/DokumentasjonsConfig';
+
+const ErklæringSamlivsbrudd: IDokumentasjon =
+  DokumentasjonsConfig.ErklæringSamlivsbrudd;
+
+const DokumentasjonInngåttEkteskap: IDokumentasjon =
+  DokumentasjonsConfig.DokumentasjonInngåttEkteskap;
+
+const DokumentasjonUformeltSeparertEllerSkilt: IDokumentasjon =
+  DokumentasjonsConfig.DokumentasjonUformeltSeparertEllerSkilt;
+
+export const BekreftelseSeparasjonSøknad: IDokumentasjon =
+  DokumentasjonsConfig.BekreftelseSeparasjonSøknad;
+
+export const harSøktSeparasjonSpørsmål = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: ESivilstatusSøknadid.harSøktSeparasjon,
+  tekstid: 'sivilstatus.spm.søktSeparasjon',
+  flersvar: false,
+  svaralternativer: [
+    { ...JaSvar(intl), dokumentasjonsbehov: BekreftelseSeparasjonSøknad },
+    NeiSvar(intl),
+  ],
+});
+
+export const erUformeltGiftSpørsmål = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: ESivilstatusSøknadid.erUformeltGift,
+  tekstid: 'sivilstatus.spm.erUformeltGift',
+  lesmer: {
+    headerTekstid: 'sivilstatus.lesmer-åpne.erUformeltGift',
+    innholdTekstid: 'sivilstatus.lesmer-innhold.erUformeltGift',
+  },
+  flersvar: false,
+  svaralternativer: [
+    {
+      ...JaSvar(intl),
+      alert_tekstid: 'sivilstatus.alert.erUformeltGift',
+      dokumentasjonsbehov: DokumentasjonInngåttEkteskap,
+    },
+    NeiSvar(intl),
+  ],
+});
+
+export const erUformeltSeparertEllerSkiltSpørsmål = (
+  intl: LokalIntlShape
+): ISpørsmål => ({
+  søknadid: ESivilstatusSøknadid.erUformeltSeparertEllerSkilt,
+  tekstid: 'sivilstatus.spm.erUformeltSeparertEllerSkilt',
+  flersvar: false,
+  svaralternativer: [
+    {
+      ...JaSvar(intl),
+      alert_tekstid: 'sivilstatus.alert.erUformeltSeparertEllerSkilt',
+      dokumentasjonsbehov: DokumentasjonUformeltSeparertEllerSkilt,
+    },
+    NeiSvar(intl),
+  ],
+});
+
+export const begrunnelseSpørsmål = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: ESivilstatusSøknadid.årsakEnslig,
+  tekstid: 'sivilstatus.spm.begrunnelse',
+  flersvar: false,
+  lesmer: {
+    innholdTekstid: 'sivilstatus.hjelpetekst-innhold.begrunnelse',
+    headerTekstid: 'sivilstatus.hjelpetekst-åpne.begrunnelse',
+  },
+  svaralternativer: [
+    {
+      id: EBegrunnelse.samlivsbruddForeldre,
+      svar_tekst: intl.formatMessage({
+        id: 'sivilstatus.svar.samlivsbruddForeldre',
+      }),
+      alert_tekstid: 'sivilstatus.alert.samlivsbrudd',
+      dokumentasjonsbehov: ErklæringSamlivsbrudd,
+    },
+    {
+      id: EBegrunnelse.samlivsbruddAndre,
+      svar_tekst: intl.formatMessage({
+        id: 'sivilstatus.svar.samlivsbruddAndre',
+      }),
+    },
+    {
+      id: EBegrunnelse.aleneFraFødsel,
+      svar_tekst: intl.formatMessage({ id: 'sivilstatus.svar.aleneFraFødsel' }),
+    },
+    {
+      id: EBegrunnelse.endringISamværsordning,
+      svar_tekst: intl.formatMessage({
+        id: 'sivilstatus.svar.endringISamværsordning',
+      }),
+    },
+    {
+      id: EBegrunnelse.dødsfall,
+      svar_tekst: intl.formatMessage({ id: 'sivilstatus.svar.dødsfall' }),
+      alert_tekstid: 'sivilstatus.alert.dødsfall',
+    },
+  ],
+});

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/SpørsmålGiftSeparertEllerSkiltIkkeRegistrert.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/SpørsmålGiftSeparertEllerSkiltIkkeRegistrert.tsx
@@ -1,0 +1,88 @@
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import JaNeiSpørsmål from '../../../../components/spørsmål/JaNeiSpørsmål';
+import {
+  erUformeltGiftSpørsmål,
+  erUformeltSeparertEllerSkiltSpørsmål,
+} from './SivilstatusConfig';
+import {
+  ESvar,
+  ISpørsmål,
+  ISvar,
+} from '../../../../models/felles/spørsmålogsvar';
+import AlertstripeDokumentasjon from '../../../../components/AlertstripeDokumentasjon';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import { hentSvarAlertFraSpørsmål } from '../../../../utils/søknad';
+import React from 'react';
+import { ISivilstatus } from '../../../../models/steg/omDeg/sivilstatus';
+import Show from '../../../../utils/showIf';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { ISpørsmålBooleanFelt } from '../../../../models/søknad/søknadsfelter';
+import { hentValgtSvar } from '../../../../utils/sivilstatus';
+
+interface Props {
+  sivilstatus: ISivilstatus;
+  settSivilstatusFelt: (spørsmål: ISpørsmål, valgtSvar: ISvar) => void;
+  erUformeltGift: ISpørsmålBooleanFelt | undefined;
+}
+
+const SpørsmålGiftSeparertEllerSkiltIkkeRegistrert: React.FC<Props> = ({
+  sivilstatus,
+  settSivilstatusFelt,
+  erUformeltGift,
+}: Props) => {
+  const intl = useLokalIntlContext();
+
+  const harSvartJaPåUformeltGift =
+    sivilstatus.erUformeltGift?.svarid === ESvar.JA;
+
+  const harSvartJaUformeltSeparertEllerSkilt =
+    sivilstatus.erUformeltSeparertEllerSkilt?.svarid === ESvar.JA;
+
+  const harSvartPåUformeltGiftSpørsmålet = erUformeltGift?.verdi !== undefined;
+
+  return (
+    <>
+      <KomponentGruppe>
+        <JaNeiSpørsmål
+          spørsmål={erUformeltGiftSpørsmål(intl)}
+          onChange={settSivilstatusFelt}
+          valgtSvar={hentValgtSvar(erUformeltGiftSpørsmål(intl), sivilstatus)}
+        />
+        <Show if={harSvartJaPåUformeltGift}>
+          <AlertstripeDokumentasjon>
+            <LocaleTekst
+              tekst={hentSvarAlertFraSpørsmål(
+                ESvar.JA,
+                erUformeltGiftSpørsmål(intl)
+              )}
+            />
+          </AlertstripeDokumentasjon>
+        </Show>
+      </KomponentGruppe>
+      <Show if={harSvartPåUformeltGiftSpørsmålet}>
+        <KomponentGruppe>
+          <JaNeiSpørsmål
+            spørsmål={erUformeltSeparertEllerSkiltSpørsmål(intl)}
+            onChange={settSivilstatusFelt}
+            valgtSvar={hentValgtSvar(
+              erUformeltSeparertEllerSkiltSpørsmål(intl),
+              sivilstatus
+            )}
+          />
+          <Show if={harSvartJaUformeltSeparertEllerSkilt}>
+            <AlertstripeDokumentasjon>
+              <LocaleTekst
+                tekst={hentSvarAlertFraSpørsmål(
+                  ESvar.JA,
+                  erUformeltSeparertEllerSkiltSpørsmål(intl)
+                )}
+              />
+            </AlertstripeDokumentasjon>
+          </Show>
+        </KomponentGruppe>
+      </Show>
+    </>
+  );
+};
+
+export default SpørsmålGiftSeparertEllerSkiltIkkeRegistrert;

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/SøkerErGift.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/SøkerErGift.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import JaNeiSpørsmål from '../../../../components/spørsmål/JaNeiSpørsmål';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import { harSøktSeparasjonSpørsmål } from './SivilstatusConfig';
+import SøkerHarSøktSeparasjon from './SøkerHarSøktSeparasjon';
+import { ISivilstatus } from '../../../../models/steg/omDeg/sivilstatus';
+import styled from 'styled-components';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { Alert } from '@navikt/ds-react';
+
+interface Props {
+  settJaNeiFelt: (spørsmål: ISpørsmål, valgtSvar: ISvar) => void;
+  settDato: (date: string, objektnøkkel: string, tekst: string) => void;
+  sivilstatus: ISivilstatus;
+}
+
+const SøktSeparasjonAlert = styled(Alert)`
+  margin-bottom: 3rem;
+`;
+
+const SøkerErGift: React.FC<Props> = ({
+  settJaNeiFelt,
+  settDato,
+  sivilstatus,
+}) => {
+  const separasjonsSpørsmål: ISpørsmål = harSøktSeparasjonSpørsmål(
+    useLokalIntlContext()
+  );
+  const { harSøktSeparasjon } = sivilstatus;
+
+  return (
+    <>
+      <KomponentGruppe>
+        <JaNeiSpørsmål
+          spørsmål={separasjonsSpørsmål}
+          onChange={settJaNeiFelt}
+          valgtSvar={harSøktSeparasjon ? harSøktSeparasjon.verdi : undefined}
+        />
+      </KomponentGruppe>
+      {harSøktSeparasjon?.verdi ? (
+        <SøkerHarSøktSeparasjon sivilstatus={sivilstatus} settDato={settDato} />
+      ) : (
+        harSøktSeparasjon?.verdi === false && (
+          <SøktSeparasjonAlert variant="warning" inline>
+            <LocaleTekst tekst={'sivilstatus.alert-advarsel.søktSeparasjon'} />
+          </SøktSeparasjonAlert>
+        )
+      )}
+    </>
+  );
+};
+
+export default SøkerErGift;

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/SøkerHarSøktSeparasjon.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/SøkerHarSøktSeparasjon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import { ISivilstatus } from '../../../../models/steg/omDeg/sivilstatus';
+import AlertStripeDokumentasjon from '../../../../components/AlertstripeDokumentasjon';
+import {
+  Datovelger,
+  DatoBegrensning,
+} from '../../../../components/dato/Datovelger';
+
+interface Props {
+  sivilstatus: ISivilstatus;
+  settDato: (date: string, objektnøkkel: string, tekst: string) => void;
+}
+const SøkerHarSøktSeparasjon: React.FC<Props> = ({ settDato, sivilstatus }) => {
+  const { datoSøktSeparasjon } = sivilstatus;
+  const datovelgerTekstid = 'sivilstatus.datovelger.søktSeparasjon';
+  return (
+    <KomponentGruppe>
+      <FeltGruppe>
+        <Datovelger
+          settDato={(e) => settDato(e, 'datoSøktSeparasjon', datovelgerTekstid)}
+          valgtDato={datoSøktSeparasjon ? datoSøktSeparasjon.verdi : undefined}
+          tekstid={datovelgerTekstid}
+          datobegrensning={DatoBegrensning.TidligereDatoer}
+        />
+      </FeltGruppe>
+      <FeltGruppe>
+        <AlertStripeDokumentasjon>
+          <LocaleTekst tekst={'sivilstatus.alert-info.søktSeparasjon'} />
+        </AlertStripeDokumentasjon>
+      </FeltGruppe>
+    </KomponentGruppe>
+  );
+};
+
+export default SøkerHarSøktSeparasjon;

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/DatoForSamlivsbrudd.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/DatoForSamlivsbrudd.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  Datovelger,
+  DatoBegrensning,
+} from '../../../../../components/dato/Datovelger';
+import LocaleTekst from '../../../../../language/LocaleTekst';
+import KomponentGruppe from '../../../../../components/gruppe/KomponentGruppe';
+import { IDatoFelt } from '../../../../../models/søknad/søknadsfelter';
+import AlertStripeDokumentasjon from '../../../../../components/AlertstripeDokumentasjon';
+
+interface Props {
+  settDato: (date: string, objektnøkkel: string, tekstid: string) => void;
+  datoForSamlivsbrudd: IDatoFelt | undefined;
+}
+
+const DatoForSamlivsbrudd: React.FC<Props> = ({
+  settDato,
+  datoForSamlivsbrudd,
+}) => {
+  const datovelgerLabel = 'sivilstatus.datovelger.samlivsbrudd';
+
+  return (
+    <>
+      <KomponentGruppe>
+        <Datovelger
+          settDato={(e) => settDato(e, 'datoForSamlivsbrudd', datovelgerLabel)}
+          valgtDato={datoForSamlivsbrudd ? datoForSamlivsbrudd?.verdi : ''}
+          tekstid={datovelgerLabel}
+          datobegrensning={DatoBegrensning.TidligereDatoer}
+        />
+        <AlertStripeDokumentasjon>
+          <LocaleTekst tekst={'sivilstatus.alert.samlivsbrudd'} />
+        </AlertStripeDokumentasjon>
+      </KomponentGruppe>
+    </>
+  );
+};
+
+export default DatoForSamlivsbrudd;

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/EndringISamvær.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/EndringISamvær.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import KomponentGruppe from '../../../../../components/gruppe/KomponentGruppe';
+import { IDatoFelt } from '../../../../../models/søknad/søknadsfelter';
+import {
+  Datovelger,
+  DatoBegrensning,
+} from '../../../../../components/dato/Datovelger';
+
+interface Props {
+  settDato: (date: string, objektnøkkel: string, tekstid: string) => void;
+  datoEndretSamvær: IDatoFelt | undefined;
+}
+const EndringISamvær: React.FC<Props> = ({ settDato, datoEndretSamvær }) => {
+  const datovelgerTekstid = 'sivilstatus.datovelger.endring';
+  return (
+    <KomponentGruppe>
+      <Datovelger
+        settDato={(e) => settDato(e, 'datoEndretSamvær', datovelgerTekstid)}
+        valgtDato={datoEndretSamvær ? datoEndretSamvær.verdi : undefined}
+        tekstid={datovelgerTekstid}
+        datobegrensning={DatoBegrensning.AlleDatoer}
+      />
+    </KomponentGruppe>
+  );
+};
+
+export default EndringISamvær;

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/NårFlyttetDereFraHverandre.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/NårFlyttetDereFraHverandre.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import KomponentGruppe from '../../../../../components/gruppe/KomponentGruppe';
+import { IDatoFelt } from '../../../../../models/søknad/søknadsfelter';
+import {
+  DatoBegrensning,
+  Datovelger,
+} from '../../../../../components/dato/Datovelger';
+
+interface Props {
+  settDato: (date: string, objektnøkkel: string, tekstid: string) => void;
+  datoFlyttetFraHverandre: IDatoFelt | undefined;
+}
+
+const NårFlyttetDereFraHverandre: React.FC<Props> = ({
+  settDato,
+  datoFlyttetFraHverandre,
+}) => {
+  const datovelgerTekstid = 'sivilstatus.datovelger.flyttetFraHverandre';
+
+  return (
+    <KomponentGruppe>
+      <Datovelger
+        settDato={(e) =>
+          settDato(e, 'datoFlyttetFraHverandre', datovelgerTekstid)
+        }
+        valgtDato={
+          datoFlyttetFraHverandre ? datoFlyttetFraHverandre.verdi : undefined
+        }
+        tekstid={datovelgerTekstid}
+        datobegrensning={DatoBegrensning.AlleDatoer}
+      />
+    </KomponentGruppe>
+  );
+};
+
+export default NårFlyttetDereFraHverandre;

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/ÅrsakEnslig.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/ÅrsakEnslig.tsx
@@ -23,7 +23,6 @@ import {
 } from '../../../../../models/søknad/person';
 import LocaleTekst from '../../../../../language/LocaleTekst';
 import { harFyltUtSamboerDetaljer } from '../../../../../utils/person';
-import { IMedlemskap } from '../../../../../models/steg/omDeg/medlemskap';
 import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
 import FormattedHtmlMessage from '../../../../../language/FormattedHtmlMessage';
 import { Alert, Heading } from '@navikt/ds-react';
@@ -31,7 +30,6 @@ import { TextFieldMedBredde } from '../../../../../components/TextFieldMedBredde
 
 interface Props {
   sivilstatus: ISivilstatus;
-  settMedlemskap: (medlemskap: IMedlemskap) => void;
   settSivilstatus: (sivilstatus: ISivilstatus) => void;
   settDato: (date: string, objektnøkkel: string, tekstid: string) => void;
   settDokumentasjonsbehov: (
@@ -46,7 +44,6 @@ const ÅrsakEnslig: FC<Props> = ({
   settSivilstatus,
   settDato,
   settDokumentasjonsbehov,
-  settMedlemskap,
 }) => {
   const intl = useLokalIntlContext();
   const spørsmål: ISpørsmål = begrunnelseSpørsmål(intl);
@@ -101,8 +98,6 @@ const ÅrsakEnslig: FC<Props> = ({
       const nySivilstatus = { ...sivilstatus };
       delete nySamboerInfo.ident;
       delete nySivilstatus.datoFlyttetFraHverandre;
-
-      settMedlemskap({});
 
       settSamboerInfo(nySamboerInfo);
       settSivilstatus(nySivilstatus);

--- a/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/ÅrsakEnslig.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/sivilstatus/begrunnelse/ÅrsakEnslig.tsx
@@ -1,0 +1,280 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import React, { FC, useEffect, useState } from 'react';
+import DatoForSamlivsbrudd from './DatoForSamlivsbrudd';
+import EndringISamvær from './EndringISamvær';
+import KomponentGruppe from '../../../../../components/gruppe/KomponentGruppe';
+import MultiSvarSpørsmål from '../../../../../components/spørsmål/MultiSvarSpørsmål';
+import NårFlyttetDereFraHverandre from './NårFlyttetDereFraHverandre';
+import { begrunnelseSpørsmål } from '../SivilstatusConfig';
+import FeltGruppe from '../../../../../components/gruppe/FeltGruppe';
+import IdentEllerFødselsdatoGruppe from '../../../../../components/gruppe/IdentEllerFødselsdatoGruppe';
+import {
+  hentSvarAlertFraSpørsmål,
+  hentTekst,
+} from '../../../../../utils/søknad';
+import {
+  EBegrunnelse,
+  ISivilstatus,
+} from '../../../../../models/steg/omDeg/sivilstatus';
+import { ISpørsmål, ISvar } from '../../../../../models/felles/spørsmålogsvar';
+import {
+  EPersonDetaljer,
+  IPersonDetaljer,
+} from '../../../../../models/søknad/person';
+import LocaleTekst from '../../../../../language/LocaleTekst';
+import { harFyltUtSamboerDetaljer } from '../../../../../utils/person';
+import { IMedlemskap } from '../../../../../models/steg/omDeg/medlemskap';
+import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
+import FormattedHtmlMessage from '../../../../../language/FormattedHtmlMessage';
+import { Alert, Heading } from '@navikt/ds-react';
+import { TextFieldMedBredde } from '../../../../../components/TextFieldMedBredde';
+
+interface Props {
+  sivilstatus: ISivilstatus;
+  settMedlemskap: (medlemskap: IMedlemskap) => void;
+  settSivilstatus: (sivilstatus: ISivilstatus) => void;
+  settDato: (date: string, objektnøkkel: string, tekstid: string) => void;
+  settDokumentasjonsbehov: (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar,
+    erHuketAv?: boolean
+  ) => void;
+}
+
+const ÅrsakEnslig: FC<Props> = ({
+  sivilstatus,
+  settSivilstatus,
+  settDato,
+  settDokumentasjonsbehov,
+  settMedlemskap,
+}) => {
+  const intl = useLokalIntlContext();
+  const spørsmål: ISpørsmål = begrunnelseSpørsmål(intl);
+
+  const {
+    årsakEnslig,
+    datoForSamlivsbrudd,
+    datoFlyttetFraHverandre,
+    datoEndretSamvær,
+    tidligereSamboerDetaljer,
+  } = sivilstatus;
+
+  const [samboerInfo, settSamboerInfo] = useState<IPersonDetaljer>(
+    tidligereSamboerDetaljer
+      ? tidligereSamboerDetaljer
+      : { kjennerIkkeIdent: false }
+  );
+
+  const [erGyldigIdent, settGyldigIdent] = useState<boolean>(
+    !!tidligereSamboerDetaljer?.ident?.verdi
+  );
+
+  const [ident, settIdent] = useState<string>(
+    samboerInfo?.ident ? samboerInfo?.ident.verdi : ''
+  );
+
+  useEffect(() => {
+    samlivsbruddAndre &&
+      settSivilstatus({
+        ...sivilstatus,
+        tidligereSamboerDetaljer: samboerInfo,
+      });
+    // eslint-disable-next-line
+  }, [samboerInfo, datoFlyttetFraHverandre]);
+
+  useEffect(() => {
+    erGyldigIdent &&
+      settSamboerInfo({
+        ...samboerInfo,
+        [EPersonDetaljer.ident]: {
+          label: hentTekst('person.ident', intl),
+          verdi: ident,
+        },
+      });
+
+    const harGyldigSamboerInfo =
+      erGyldigIdent ||
+      (samboerInfo.kjennerIkkeIdent && samboerInfo.fødselsdato);
+
+    if (!harGyldigSamboerInfo && samlivsbruddAndre) {
+      const nySamboerInfo = { ...samboerInfo };
+      const nySivilstatus = { ...sivilstatus };
+      delete nySamboerInfo.ident;
+      delete nySivilstatus.datoFlyttetFraHverandre;
+
+      settMedlemskap({});
+
+      settSamboerInfo(nySamboerInfo);
+      settSivilstatus(nySivilstatus);
+    }
+
+    // eslint-disable-next-line
+  }, [erGyldigIdent, ident]);
+
+  const settNavn = (e: React.FormEvent<HTMLInputElement>) => {
+    settSamboerInfo({
+      ...samboerInfo,
+      [EPersonDetaljer.navn]: {
+        label: hentTekst('person.navn', intl),
+        verdi: e.currentTarget.value,
+      },
+    });
+  };
+
+  const oppdaterIdent = (e: React.FormEvent<HTMLInputElement>) => {
+    settIdent(e.currentTarget.value);
+  };
+
+  const hvisGyldigIdentSettIdentISamboerDetaljer = (erGyldig: boolean) => {
+    settGyldigIdent(erGyldig);
+  };
+
+  const settChecked = (checked: boolean) => {
+    const endretSamboerInfo = samboerInfo;
+    if (checked && endretSamboerInfo.ident?.verdi) {
+      delete endretSamboerInfo.ident;
+      settIdent('');
+    }
+    if (!checked && endretSamboerInfo.fødselsdato?.verdi)
+      delete endretSamboerInfo.fødselsdato;
+
+    settSamboerInfo({ ...endretSamboerInfo, kjennerIkkeIdent: checked });
+  };
+
+  const settFødselsdato = (date: string) => {
+    settSamboerInfo({
+      ...samboerInfo,
+      fødselsdato: {
+        label: hentTekst('datovelger.fødselsdato', intl),
+        verdi: date,
+      },
+    });
+  };
+
+  const erBegrunnelse = (svaralternativ: EBegrunnelse): boolean => {
+    return årsakEnslig?.svarid === svaralternativ;
+  };
+  const samlivsbruddAndre: boolean = erBegrunnelse(
+    EBegrunnelse.samlivsbruddAndre
+  );
+
+  const settÅrsakEnslig = (spørsmål: ISpørsmål, svar: ISvar) => {
+    const spørsmålTekst: string = hentTekst(spørsmål.tekstid, intl);
+
+    const nyttSivilstatusObjekt = fjernIrrelevanteSøknadsfelter(svar);
+
+    settSivilstatus({
+      ...nyttSivilstatusObjekt,
+      årsakEnslig: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: svar.id,
+        label: spørsmålTekst,
+        verdi: svar.svar_tekst,
+      },
+    });
+    settDokumentasjonsbehov(spørsmål, svar);
+  };
+
+  if (!samlivsbruddAndre) {
+    delete sivilstatus.tidligereSamboerDetaljer;
+  }
+
+  const fjernIrrelevanteSøknadsfelter = (svar: ISvar): ISivilstatus => {
+    const nySivilStatusObjekt = sivilstatus;
+    if (svar.id !== EBegrunnelse.samlivsbruddForeldre && datoForSamlivsbrudd) {
+      delete nySivilStatusObjekt.datoForSamlivsbrudd;
+    }
+    if (svar.id !== EBegrunnelse.samlivsbruddAndre && datoFlyttetFraHverandre) {
+      delete nySivilStatusObjekt.datoFlyttetFraHverandre;
+    }
+
+    if (svar.id !== EBegrunnelse.endringISamværsordning && datoEndretSamvær) {
+      delete nySivilStatusObjekt.datoEndretSamvær;
+    }
+    return nySivilStatusObjekt;
+  };
+
+  const alertTekstForDødsfall = hentSvarAlertFraSpørsmål(
+    EBegrunnelse.dødsfall,
+    spørsmål
+  );
+
+  return (
+    <div aria-live="polite">
+      <KomponentGruppe>
+        <MultiSvarSpørsmål
+          key={spørsmål.tekstid}
+          spørsmål={spørsmål}
+          valgtSvar={sivilstatus.årsakEnslig?.verdi}
+          settSpørsmålOgSvar={settÅrsakEnslig}
+        />
+      </KomponentGruppe>
+
+      {årsakEnslig?.svarid === EBegrunnelse.samlivsbruddForeldre && (
+        <DatoForSamlivsbrudd
+          settDato={settDato}
+          datoForSamlivsbrudd={datoForSamlivsbrudd}
+        />
+      )}
+
+      {årsakEnslig?.svarid === EBegrunnelse.samlivsbruddAndre && (
+        <KomponentGruppe>
+          <FeltGruppe>
+            <Heading size="small" level="3">
+              <LocaleTekst tekst={'sivilstatus.tittel.samlivsbruddAndre'} />
+            </Heading>
+          </FeltGruppe>
+          <FeltGruppe>
+            <TextFieldMedBredde
+              key={'navn'}
+              label={hentTekst('person.navn', intl)}
+              type="text"
+              bredde={'L'}
+              onChange={(e) => settNavn(e)}
+              value={samboerInfo?.navn?.verdi}
+            />
+          </FeltGruppe>
+          <FeltGruppe>
+            <IdentEllerFødselsdatoGruppe
+              identLabel={hentTekst('person.ident', intl)}
+              datoLabel={hentTekst('datovelger.fødselsdato', intl)}
+              checkboxLabel={hentTekst('person.checkbox.ident', intl)}
+              ident={ident && !samboerInfo.kjennerIkkeIdent ? ident : ''}
+              fødselsdato={samboerInfo.fødselsdato?.verdi || ''}
+              checked={samboerInfo?.kjennerIkkeIdent}
+              erGyldigIdent={erGyldigIdent}
+              settGyldigIdent={hvisGyldigIdentSettIdentISamboerDetaljer}
+              settFødselsdato={settFødselsdato}
+              settChecked={settChecked}
+              settIdent={oppdaterIdent}
+            />
+          </FeltGruppe>
+
+          {harFyltUtSamboerDetaljer(samboerInfo, false) && (
+            <NårFlyttetDereFraHverandre
+              settDato={settDato}
+              datoFlyttetFraHverandre={datoFlyttetFraHverandre}
+            />
+          )}
+        </KomponentGruppe>
+      )}
+
+      {årsakEnslig?.svarid === EBegrunnelse.endringISamværsordning && (
+        <EndringISamvær
+          settDato={settDato}
+          datoEndretSamvær={datoEndretSamvær}
+        />
+      )}
+
+      {årsakEnslig?.svarid === EBegrunnelse.dødsfall && (
+        <KomponentGruppe>
+          <Alert size="small" variant="info" inline>
+            <FormattedHtmlMessage id={alertTekstForDødsfall} />
+          </Alert>
+        </KomponentGruppe>
+      )}
+    </div>
+  );
+};
+
+export default ÅrsakEnslig;

--- a/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
@@ -4,7 +4,6 @@ import { IBosituasjon } from '../../../models/steg/bosituasjon';
 import { useLocation } from 'react-router-dom';
 import { erFerdigUtfylt } from '../../../helpers/steg/bosituasjon';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
-import BosituasjonSpørsmål from '../../../søknad/steg/2-bosituasjon/BosituasjonSpørsmål';
 import Side, { ESide } from '../../../components/side/Side';
 import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
@@ -14,6 +13,7 @@ import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
 import { ISøknad } from '../../models/søknad';
 import { kommerFraOppsummeringen } from '../../../utils/locationState';
+import BosituasjonSpørsmål from './BosituasjonSpørsmål';
 
 const Bosituasjon: FC = () => {
   useMount(() => logSidevisningBarnetilsyn('Bosituasjon'));

--- a/src/barnetilsyn/steg/2-bosituasjon/BosituasjonConfig.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/BosituasjonConfig.tsx
@@ -1,0 +1,77 @@
+import { ISpørsmål } from '../../../models/felles/spørsmålogsvar';
+import {
+  EBosituasjon,
+  ESøkerDelerBolig,
+} from '../../../models/steg/bosituasjon';
+import { JaNeiSvar } from '../../../helpers/svar';
+import { IDokumentasjon } from '../../../models/steg/dokumentasjon';
+import { DokumentasjonsConfig } from '../../DokumentasjonsConfig';
+import { LokalIntlShape } from '../../../language/typer';
+
+// --- Dokumentasjon
+
+const DokumentasjonBorPåUlikeAdresser: IDokumentasjon =
+  DokumentasjonsConfig.DokumentasjonBorPåUlikeAdresser;
+
+// --- Spørsmål
+
+export const delerSøkerBoligMedAndreVoksne = (
+  intl: LokalIntlShape
+): ISpørsmål => ({
+  søknadid: EBosituasjon.delerBoligMedAndreVoksne,
+  tekstid: 'bosituasjon.spm.delerSøkerBoligMedAndreVoksne',
+  flersvar: false,
+  svaralternativer: [
+    {
+      id: ESøkerDelerBolig.borSammenOgVenterBarn,
+      svar_tekst: intl.formatMessage({
+        id: 'bosituasjon.svar.borSammenOgVenterBarn',
+      }),
+      alert_tekstid: 'bosituasjon.alert.borSammenOgVenterBarn',
+    },
+    {
+      id: ESøkerDelerBolig.borMidlertidigFraHverandre,
+      svar_tekst: intl.formatMessage({
+        id: 'bosituasjon.svar.borMidlertidigFraHverandre',
+      }),
+      alert_tekstid: 'bosituasjon.alert.borMidlertidigFraHverandre',
+    },
+    {
+      id: ESøkerDelerBolig.harEkteskapsliknendeForhold,
+      svar_tekst: intl.formatMessage({
+        id: 'bosituasjon.svar.harEkteskapsliknendeForhold',
+      }),
+      alert_tekstid: 'bosituasjon.alert.harEkteskapsliknendeForhold',
+    },
+    {
+      id: ESøkerDelerBolig.delerBoligMedAndreVoksne,
+      svar_tekst: intl.formatMessage({
+        id: 'bosituasjon.svar.delerBoligMedAndreVoksne',
+      }),
+    },
+    {
+      id: ESøkerDelerBolig.tidligereSamboerFortsattRegistrertPåAdresse,
+      svar_tekst: intl.formatMessage({
+        id: 'bosituasjon.svar.tidligereSamboerFortsattRegistrertPåAdresse',
+      }),
+      alert_tekstid:
+        'bosituasjon.alert.tidligereSamboerFortsattRegistrertPåAdresse',
+      dokumentasjonsbehov: DokumentasjonBorPåUlikeAdresser,
+    },
+    {
+      id: ESøkerDelerBolig.borAleneMedBarnEllerGravid,
+      svar_tekst: intl.formatMessage({
+        id: 'bosituasjon.svar.borAleneMedBarnEllerGravid',
+      }),
+    },
+  ],
+});
+
+export const skalSøkerGifteSegMedSamboer = (
+  intl: LokalIntlShape
+): ISpørsmål => ({
+  søknadid: EBosituasjon.skalGifteSegEllerBliSamboer,
+  tekstid: 'bosituasjon.spm.skalSøkerGifteSegMedSamboer',
+  flersvar: false,
+  svaralternativer: JaNeiSvar(intl),
+});

--- a/src/barnetilsyn/steg/2-bosituasjon/BosituasjonSpørsmål.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/BosituasjonSpørsmål.tsx
@@ -1,0 +1,151 @@
+import React, { FC } from 'react';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import MultiSvarSpørsmål from '../../../components/spørsmål/MultiSvarSpørsmål';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import AlertStripeDokumentasjon from '../../../components/AlertstripeDokumentasjon';
+import {
+  ESøkerDelerBolig,
+  IBosituasjon,
+} from '../../../models/steg/bosituasjon';
+import LocaleTekst from '../../../language/LocaleTekst';
+import SøkerSkalFlytteSammenEllerFåSamboer from './SøkerSkalFlytteSammenEllerFåSamboer';
+import EkteskapsliknendeForhold from './EkteskapsliknendeForhold';
+import OmTidligereSamboer from './OmTidligereSamboer';
+import { hentTekst } from '../../../utils/søknad';
+import { ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
+import { delerSøkerBoligMedAndreVoksne } from './BosituasjonConfig';
+import {
+  erValgtSvarLiktSomSvar,
+  harValgtSvar,
+} from '../../../utils/spørsmålogsvar';
+import { erDatoGyldigOgInnaforBegrensninger } from '../../../components/dato/utils';
+import { DatoBegrensning } from '../../../components/dato/Datovelger';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import FormattedHtmlMessage from '../../../language/FormattedHtmlMessage';
+import { Alert } from '@navikt/ds-react';
+
+interface Props {
+  bosituasjon: IBosituasjon;
+  settBosituasjon: (bosituasjon: IBosituasjon) => void;
+  settDokumentasjonsbehov: (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar,
+    erHuketAv?: boolean
+  ) => void;
+}
+
+const BosituasjonSpørsmål: FC<Props> = ({
+  bosituasjon,
+  settBosituasjon,
+  settDokumentasjonsbehov,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const { delerBoligMedAndreVoksne, samboerDetaljer, datoFlyttetFraHverandre } =
+    bosituasjon;
+
+  const hovedSpørsmål: ISpørsmål = delerSøkerBoligMedAndreVoksne(intl);
+
+  const settBosituasjonFelt = (spørsmål: ISpørsmål, svar: ISvar) => {
+    const svarTekst: string = svar.svar_tekst;
+    const spørsmålTekst: string = hentTekst(spørsmål.tekstid, intl);
+
+    const nyBosituasjon = {
+      delerBoligMedAndreVoksne: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: svar.id,
+        label: spørsmålTekst,
+        verdi: svarTekst,
+      },
+    };
+
+    settBosituasjon(nyBosituasjon);
+    settDokumentasjonsbehov(spørsmål, svar);
+  };
+
+  const valgtSvar: ISvar | undefined = hovedSpørsmål.svaralternativer.find(
+    (svar) =>
+      erValgtSvarLiktSomSvar(delerBoligMedAndreVoksne.verdi, svar.svar_tekst)
+  );
+
+  const harSøkerEkteskapsliknendeForhold =
+    delerBoligMedAndreVoksne.svarid ===
+    ESøkerDelerBolig.harEkteskapsliknendeForhold;
+
+  const harSattDatoFlyttetFraHverandre: boolean = !!(
+    datoFlyttetFraHverandre?.verdi &&
+    erDatoGyldigOgInnaforBegrensninger(
+      datoFlyttetFraHverandre?.verdi,
+      DatoBegrensning.AlleDatoer
+    )
+  );
+  const tidligereSamboerFortsattRegistrertPåAdresse =
+    delerBoligMedAndreVoksne.svarid ===
+      ESøkerDelerBolig.tidligereSamboerFortsattRegistrertPåAdresse &&
+    harSattDatoFlyttetFraHverandre &&
+    harValgtSvar(samboerDetaljer?.navn?.verdi) &&
+    harValgtSvar(datoFlyttetFraHverandre?.verdi);
+
+  const planerOmÅFlytteSammenEllerFåSamboer =
+    delerBoligMedAndreVoksne.svarid ===
+      ESøkerDelerBolig.borAleneMedBarnEllerGravid ||
+    delerBoligMedAndreVoksne.svarid ===
+      ESøkerDelerBolig.delerBoligMedAndreVoksne ||
+    tidligereSamboerFortsattRegistrertPåAdresse;
+
+  return (
+    <>
+      <SeksjonGruppe>
+        <MultiSvarSpørsmål
+          key={hovedSpørsmål.søknadid}
+          spørsmål={hovedSpørsmål}
+          valgtSvar={delerBoligMedAndreVoksne.verdi}
+          settSpørsmålOgSvar={settBosituasjonFelt}
+        />
+        {valgtSvar && valgtSvar.alert_tekstid && (
+          <FeltGruppe>
+            {delerBoligMedAndreVoksne.svarid ===
+            ESøkerDelerBolig.tidligereSamboerFortsattRegistrertPåAdresse ? (
+              <AlertStripeDokumentasjon>
+                <FormattedHtmlMessage id={valgtSvar.alert_tekstid} />
+              </AlertStripeDokumentasjon>
+            ) : (
+              <Alert size="small" variant="warning" inline>
+                <LocaleTekst tekst={valgtSvar.alert_tekstid} />
+              </Alert>
+            )}
+          </FeltGruppe>
+        )}
+      </SeksjonGruppe>
+
+      {delerBoligMedAndreVoksne.svarid ===
+        ESøkerDelerBolig.tidligereSamboerFortsattRegistrertPåAdresse && (
+        <SeksjonGruppe>
+          <OmTidligereSamboer
+            bosituasjon={bosituasjon}
+            settBosituasjon={settBosituasjon}
+          />
+        </SeksjonGruppe>
+      )}
+
+      {planerOmÅFlytteSammenEllerFåSamboer && (
+        <SeksjonGruppe>
+          <SøkerSkalFlytteSammenEllerFåSamboer
+            settBosituasjon={settBosituasjon}
+            bosituasjon={bosituasjon}
+            settDokumentasjonsbehov={settDokumentasjonsbehov}
+          />
+        </SeksjonGruppe>
+      )}
+
+      {harSøkerEkteskapsliknendeForhold && (
+        <EkteskapsliknendeForhold
+          settBosituasjon={settBosituasjon}
+          bosituasjon={bosituasjon}
+        />
+      )}
+    </>
+  );
+};
+
+export default BosituasjonSpørsmål;

--- a/src/barnetilsyn/steg/2-bosituasjon/EkteskapsliknendeForhold.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/EkteskapsliknendeForhold.tsx
@@ -1,0 +1,68 @@
+import React, { FC } from 'react';
+import { EBosituasjon, IBosituasjon } from '../../../models/steg/bosituasjon';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import OmSamboerenDin from './OmSamboerenDin';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import { hentTekst } from '../../../utils/søknad';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { harFyltUtSamboerDetaljer } from '../../../utils/person';
+import {
+  DatoBegrensning,
+  Datovelger,
+} from '../../../components/dato/Datovelger';
+
+interface Props {
+  settBosituasjon: (bosituasjon: IBosituasjon) => void;
+  bosituasjon: IBosituasjon;
+}
+const EkteskapsliknendeForhold: FC<Props> = ({
+  settBosituasjon,
+  bosituasjon,
+}) => {
+  const intl = useLokalIntlContext();
+  const { samboerDetaljer } = bosituasjon;
+
+  const settDatoFlyttetSammen = (dato: string, label: string) => {
+    dato !== null &&
+      settBosituasjon({
+        ...bosituasjon,
+        datoFlyttetSammenMedSamboer: {
+          label: label,
+          verdi: dato,
+        },
+      });
+  };
+
+  return (
+    <SeksjonGruppe>
+      <OmSamboerenDin
+        tittel={'bosituasjon.tittel.omSamboer'}
+        erIdentEllerFødselsdatoObligatorisk={true}
+        settBosituasjon={settBosituasjon}
+        bosituasjon={bosituasjon}
+        samboerDetaljerType={EBosituasjon.samboerDetaljer}
+      />
+      {samboerDetaljer && harFyltUtSamboerDetaljer(samboerDetaljer, false) && (
+        <FeltGruppe>
+          <Datovelger
+            valgtDato={
+              bosituasjon.datoFlyttetSammenMedSamboer
+                ? bosituasjon.datoFlyttetSammenMedSamboer.verdi
+                : undefined
+            }
+            tekstid={'bosituasjon.datovelger.nårFlyttetDereSammen'}
+            datobegrensning={DatoBegrensning.TidligereDatoer}
+            settDato={(e) =>
+              settDatoFlyttetSammen(
+                e,
+                hentTekst('bosituasjon.datovelger.nårFlyttetDereSammen', intl)
+              )
+            }
+          />
+        </FeltGruppe>
+      )}
+    </SeksjonGruppe>
+  );
+};
+
+export default EkteskapsliknendeForhold;

--- a/src/barnetilsyn/steg/2-bosituasjon/OmSamboerenDin.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/OmSamboerenDin.tsx
@@ -1,0 +1,154 @@
+import React, { FC, useEffect, useState } from 'react';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { EBosituasjon, IBosituasjon } from '../../../models/steg/bosituasjon';
+import { hentTekst } from '../../../utils/søknad';
+import IdentEllerFødselsdatoGruppe from '../../../components/gruppe/IdentEllerFødselsdatoGruppe';
+import {
+  EPersonDetaljer,
+  IPersonDetaljer,
+} from '../../../models/søknad/person';
+import { Label } from '@navikt/ds-react';
+import { TextFieldMedBredde } from '../../../components/TextFieldMedBredde';
+
+interface Props {
+  tittel: string;
+  erIdentEllerFødselsdatoObligatorisk: boolean;
+  settBosituasjon: (bositasjon: IBosituasjon) => void;
+  bosituasjon: IBosituasjon;
+  samboerDetaljerType:
+    | EBosituasjon.samboerDetaljer
+    | EBosituasjon.vordendeSamboerEktefelle;
+}
+
+const OmSamboerenDin: FC<Props> = ({
+  tittel,
+  erIdentEllerFødselsdatoObligatorisk,
+  settBosituasjon,
+  bosituasjon,
+  samboerDetaljerType,
+}) => {
+  const intl = useLokalIntlContext();
+  const samboerDetaljer = bosituasjon[samboerDetaljerType];
+  const [samboerInfo, settSamboerInfo] = useState<IPersonDetaljer>(
+    samboerDetaljer ? samboerDetaljer : { kjennerIkkeIdent: false }
+  );
+  const [ident, settIdent] = useState<string>(
+    samboerInfo?.ident ? samboerInfo?.ident.verdi : ''
+  );
+  const [erGyldigIdent, settGyldigIdent] = useState<boolean>(
+    !!samboerDetaljer?.ident?.verdi
+  );
+
+  useEffect(() => {
+    erGyldigIdent &&
+      settSamboerInfo({
+        ...samboerInfo,
+        [EPersonDetaljer.ident]: {
+          label: hentTekst('person.ident', intl),
+          verdi: ident,
+        },
+      });
+
+    if (!erGyldigIdent) {
+      const nySamboerInfo = { ...samboerInfo };
+      delete nySamboerInfo.ident;
+
+      settSamboerInfo(nySamboerInfo);
+    }
+
+    // eslint-disable-next-line
+  }, [erGyldigIdent, ident]);
+
+  useEffect(() => {
+    settBosituasjon({
+      ...bosituasjon,
+      [samboerDetaljerType]: samboerInfo,
+    });
+    // eslint-disable-next-line
+  }, [samboerInfo]);
+
+  const settChecked = (checked: boolean) => {
+    const endretSamboerInfo = samboerInfo;
+    if (checked && endretSamboerInfo.ident?.verdi) {
+      delete endretSamboerInfo.ident;
+      settIdent('');
+    }
+    if (!checked && endretSamboerInfo.fødselsdato?.verdi)
+      delete endretSamboerInfo.fødselsdato;
+
+    settSamboerInfo({ ...endretSamboerInfo, kjennerIkkeIdent: checked });
+  };
+
+  const settFødselsdato = (date: string) => {
+    settSamboerInfo({
+      ...samboerInfo,
+      fødselsdato: {
+        label: hentTekst('datovelger.fødselsdato', intl),
+        verdi: date,
+      },
+    });
+  };
+
+  const hvisGyldigIdentSettIdentISamboerDetaljer = (erGyldig: boolean) => {
+    settGyldigIdent(erGyldig);
+  };
+
+  const oppdaterIdent = (e: React.FormEvent<HTMLInputElement>) => {
+    settIdent(e.currentTarget.value);
+  };
+
+  const settNavn = (e: React.FormEvent<HTMLInputElement>) => {
+    settSamboerInfo({
+      ...samboerInfo,
+      [EPersonDetaljer.navn]: {
+        label: hentTekst('person.navn', intl),
+        verdi: e.currentTarget.value,
+      },
+    });
+  };
+  return (
+    <>
+      <FeltGruppe>
+        <Label as="p">{hentTekst(tittel, intl)}</Label>
+      </FeltGruppe>
+
+      <KomponentGruppe>
+        <TextFieldMedBredde
+          className={'inputfelt-tekst'}
+          key={'navn'}
+          label={hentTekst('person.navn', intl)}
+          type="text"
+          bredde={'L'}
+          onChange={(e) => settNavn(e)}
+          value={samboerInfo.navn?.verdi ? samboerInfo.navn?.verdi : ''}
+        />
+      </KomponentGruppe>
+      <KomponentGruppe>
+        {samboerDetaljer?.navn && (
+          <IdentEllerFødselsdatoGruppe
+            identLabel={hentTekst('person.ident', intl)}
+            datoLabel={
+              !erIdentEllerFødselsdatoObligatorisk
+                ? hentTekst('person.fødselsdato', intl)
+                : hentTekst('datovelger.fødselsdato', intl)
+            }
+            checkboxLabel={hentTekst('person.checkbox.ident', intl)}
+            ident={ident && !samboerInfo.kjennerIkkeIdent ? ident : ''}
+            fødselsdato={samboerInfo.fødselsdato?.verdi || ''}
+            checked={samboerInfo?.kjennerIkkeIdent}
+            erGyldigIdent={erGyldigIdent}
+            settGyldigIdent={hvisGyldigIdentSettIdentISamboerDetaljer}
+            settFødselsdato={settFødselsdato}
+            settChecked={settChecked}
+            settIdent={oppdaterIdent}
+          />
+        )}
+      </KomponentGruppe>
+    </>
+  );
+};
+
+export default OmSamboerenDin;

--- a/src/barnetilsyn/steg/2-bosituasjon/OmTidligereSamboer.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/OmTidligereSamboer.tsx
@@ -1,0 +1,63 @@
+import React, { FC } from 'react';
+import { EBosituasjon, IBosituasjon } from '../../../models/steg/bosituasjon';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import OmSamboerenDin from './OmSamboerenDin';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import { hentTekst } from '../../../utils/søknad';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { harFyltUtSamboerDetaljer } from '../../../utils/person';
+import {
+  DatoBegrensning,
+  Datovelger,
+} from '../../../components/dato/Datovelger';
+interface Props {
+  settBosituasjon: (bosituasjon: IBosituasjon) => void;
+  bosituasjon: IBosituasjon;
+}
+const OmTidligereSamboer: FC<Props> = ({ settBosituasjon, bosituasjon }) => {
+  const intl = useLokalIntlContext();
+
+  const settDatoFlyttetFraHverandre = (dato: string) => {
+    dato !== null &&
+      settBosituasjon({
+        ...bosituasjon,
+        [EBosituasjon.datoFlyttetFraHverandre]: {
+          label: hentTekst(
+            'bosituasjon.datovelger.nårFlyttetDereFraHverandre',
+            intl
+          ),
+          verdi: dato,
+        },
+      });
+  };
+
+  return (
+    <SeksjonGruppe aria-live="polite">
+      <OmSamboerenDin
+        tittel={'bosituasjon.tittel.omTidligereSamboer'}
+        erIdentEllerFødselsdatoObligatorisk={false}
+        settBosituasjon={settBosituasjon}
+        bosituasjon={bosituasjon}
+        samboerDetaljerType={EBosituasjon.samboerDetaljer}
+      />
+      {bosituasjon.samboerDetaljer &&
+        harFyltUtSamboerDetaljer(bosituasjon.samboerDetaljer, true) && (
+          <FeltGruppe>
+            <Datovelger
+              aria-live="polite"
+              valgtDato={
+                bosituasjon.datoFlyttetFraHverandre
+                  ? bosituasjon.datoFlyttetFraHverandre.verdi
+                  : undefined
+              }
+              tekstid={'bosituasjon.datovelger.nårFlyttetDereFraHverandre'}
+              datobegrensning={DatoBegrensning.AlleDatoer}
+              settDato={settDatoFlyttetFraHverandre}
+            />
+          </FeltGruppe>
+        )}
+    </SeksjonGruppe>
+  );
+};
+
+export default OmTidligereSamboer;

--- a/src/barnetilsyn/steg/2-bosituasjon/SøkerSkalFlytteSammenEllerFåSamboer.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/SøkerSkalFlytteSammenEllerFåSamboer.tsx
@@ -1,0 +1,149 @@
+import React, { FC } from 'react';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import JaNeiSpørsmål from '../../../components/spørsmål/JaNeiSpørsmål';
+import { skalSøkerGifteSegMedSamboer } from './BosituasjonConfig';
+import OmSamboerenDin from './OmSamboerenDin';
+import { ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
+import {
+  EBosituasjon,
+  ESøkerDelerBolig,
+  IBosituasjon,
+} from '../../../models/steg/bosituasjon';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import {
+  harValgtSvar,
+  hentBooleanFraValgtSvar,
+} from '../../../utils/spørsmålogsvar';
+import { hentTekst } from '../../../utils/søknad';
+import {
+  DatoBegrensning,
+  Datovelger,
+} from '../../../components/dato/Datovelger';
+import { erDatoSkalGifteSegEllerBliSamboerFremEllerTilbakeITid } from '../../../helpers/steg/bosituasjon';
+
+interface Props {
+  settBosituasjon: (bosituasjon: IBosituasjon) => void;
+  bosituasjon: IBosituasjon;
+  settDokumentasjonsbehov: (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar,
+    erHuketAv?: boolean
+  ) => void;
+}
+
+const SøkerSkalFlytteSammenEllerFåSamboer: FC<Props> = ({
+  settBosituasjon,
+  bosituasjon,
+  settDokumentasjonsbehov,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const {
+    delerBoligMedAndreVoksne,
+    skalGifteSegEllerBliSamboer,
+    datoSkalGifteSegEllerBliSamboer,
+  } = bosituasjon;
+
+  const spørsmål: ISpørsmål = skalSøkerGifteSegMedSamboer(intl);
+
+  const settSøkerSkalGifteSegEllerBliSamboer = (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar
+  ) => {
+    const svar: boolean = hentBooleanFraValgtSvar(valgtSvar);
+    const nullstilltBosituasjon: IBosituasjon = {
+      delerBoligMedAndreVoksne: delerBoligMedAndreVoksne,
+      skalGifteSegEllerBliSamboer: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: valgtSvar.id,
+        label: hentTekst(spørsmål.tekstid, intl),
+        verdi: svar,
+      },
+    };
+
+    if (svar === false) {
+      delete bosituasjon.datoSkalGifteSegEllerBliSamboer;
+      delete bosituasjon.vordendeSamboerEktefelle;
+    }
+
+    harValgtSvar(svar) &&
+    bosituasjon.delerBoligMedAndreVoksne.svarid ===
+      ESøkerDelerBolig.tidligereSamboerFortsattRegistrertPåAdresse
+      ? settBosituasjon({
+          ...bosituasjon,
+          delerBoligMedAndreVoksne: delerBoligMedAndreVoksne,
+          skalGifteSegEllerBliSamboer: {
+            spørsmålid: spørsmål.søknadid,
+            svarid: valgtSvar.id,
+            label: hentTekst(spørsmål.tekstid, intl),
+            verdi: svar,
+          },
+        })
+      : settBosituasjon(nullstilltBosituasjon);
+
+    settDokumentasjonsbehov(spørsmål, valgtSvar);
+  };
+
+  const settDatoSøkerSkalGifteSegEllerBliSamboer = (
+    dato: string,
+    label: string
+  ) => {
+    settBosituasjon({
+      ...bosituasjon,
+      datoSkalGifteSegEllerBliSamboer: {
+        label: label,
+        verdi: dato,
+      },
+    });
+  };
+
+  const datovelgerTekst = intl.formatMessage({
+    id: 'datovelger.nårSkalDetteSkje',
+  });
+
+  const erSattDatoSkalGifteSegEllerBliSamboerFremEllerTilbakeITid =
+    erDatoSkalGifteSegEllerBliSamboerFremEllerTilbakeITid(
+      datoSkalGifteSegEllerBliSamboer
+    );
+
+  return (
+    <>
+      <KomponentGruppe>
+        <JaNeiSpørsmål
+          spørsmål={spørsmål}
+          onChange={settSøkerSkalGifteSegEllerBliSamboer}
+          valgtSvar={skalGifteSegEllerBliSamboer?.verdi}
+        />
+      </KomponentGruppe>
+      {skalGifteSegEllerBliSamboer && skalGifteSegEllerBliSamboer.verdi ? (
+        <>
+          <KomponentGruppe>
+            <Datovelger
+              valgtDato={datoSkalGifteSegEllerBliSamboer?.verdi}
+              tekstid={'datovelger.nårSkalDetteSkje'}
+              datobegrensning={DatoBegrensning.FremtidigeDatoer}
+              settDato={(e) => {
+                settDatoSøkerSkalGifteSegEllerBliSamboer(e, datovelgerTekst);
+              }}
+            />
+          </KomponentGruppe>
+          {erSattDatoSkalGifteSegEllerBliSamboerFremEllerTilbakeITid && (
+            <KomponentGruppe>
+              <OmSamboerenDin
+                tittel={
+                  'bosituasjon.tittel.hvemSkalSøkerGifteEllerBliSamboerMed'
+                }
+                erIdentEllerFødselsdatoObligatorisk={true}
+                settBosituasjon={settBosituasjon}
+                bosituasjon={bosituasjon}
+                samboerDetaljerType={EBosituasjon.vordendeSamboerEktefelle}
+              />
+            </KomponentGruppe>
+          )}
+        </>
+      ) : null}
+    </>
+  );
+};
+
+export default SøkerSkalFlytteSammenEllerFåSamboer;

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDine.tsx
@@ -5,7 +5,6 @@ import LesMerTekst from '../../../components/LesMerTekst';
 import FeltGruppe from '../../../components/gruppe/FeltGruppe';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 import BarnMedISøknad from './BarnMedISøknad';
-import Barnekort from '../../../søknad/steg/3-barnadine/Barnekort';
 import { IBarn } from '../../../models/steg/barn';
 import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
 import { hentPathBarnetilsynOppsummering } from '../../utils';
@@ -15,11 +14,9 @@ import LocaleTekst from '../../../language/LocaleTekst';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
 import { Alert, Label } from '@navikt/ds-react';
-import {
-  BarnaDineContainer,
-  BarneKortWrapper,
-} from '../../../søknad/steg/3-barnadine/BarnaDineInnhold';
 import styled from 'styled-components';
+import Barnekort from './Barnekort';
+import { BarnaDineContainer, BarneKortWrapper } from './BarnaDineInnhold';
 
 const AlertContainer = styled.div`
   & > *:not(:first-child) {

--- a/src/barnetilsyn/steg/3-barnadine/BarnaDineInnhold.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnaDineInnhold.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { hentTekst } from '../../../utils/søknad';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { IBarn } from '../../../models/steg/barn';
+import { Alert } from '@navikt/ds-react';
+import { SettDokumentasjonsbehovBarn } from '../../../models/søknad/søknad';
+import { EndreEllerSlettBarn } from './EndreEllerSlettBarn';
+import styled from 'styled-components';
+import Barnekort from './Barnekort';
+import LeggTilBarnModal from './LeggTilBarnModal';
+import { LeggTilBarnKort } from './LeggTilBarnKort';
+
+interface Props {
+  barneliste: IBarn[];
+  oppdaterBarnISøknaden: (oppdatertBarn: IBarn) => void;
+  fjernBarnFraSøknad: (id: string) => void;
+  settDokumentasjonsbehovForBarn: SettDokumentasjonsbehovBarn;
+}
+
+export const BarneKortWrapper = styled.div`
+  display: inline-flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  max-width: 568px;
+  margin: auto;
+
+  @media (max-width: 767px) {
+    justify-content: center;
+  }
+`;
+
+export const BarnaDineContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const BarnaDineInnhold: React.FC<Props> = ({
+  barneliste,
+  oppdaterBarnISøknaden,
+  fjernBarnFraSøknad,
+  settDokumentasjonsbehovForBarn,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const [åpenModal, settÅpenModal] = useState(false);
+
+  return (
+    <BarnaDineContainer>
+      <Alert size="small" variant="info" inline>
+        {hentTekst('barnadine.infohentet', intl)}
+      </Alert>
+      <BarneKortWrapper>
+        {barneliste
+          ?.sort((a: IBarn, b: IBarn) => {
+            if (a.medforelder?.verdi && !b.medforelder?.verdi) {
+              return -1;
+            }
+            if (!a.medforelder?.verdi && b.medforelder?.verdi) {
+              return 1;
+            }
+            return 0;
+          })
+          .map((barn: IBarn) => (
+            <Barnekort
+              key={barn.id}
+              gjeldendeBarn={barn}
+              footer={
+                barn.lagtTil && (
+                  <EndreEllerSlettBarn
+                    fjernBarnFraSøknad={fjernBarnFraSøknad}
+                    id={barn.id}
+                    settDokumentasjonsbehovForBarn={
+                      settDokumentasjonsbehovForBarn
+                    }
+                    barneListe={barneliste}
+                    oppdaterBarnISøknaden={oppdaterBarnISøknaden}
+                  />
+                )
+              }
+            />
+          ))}
+        <LeggTilBarnKort settÅpenModal={settÅpenModal} />
+      </BarneKortWrapper>
+      {åpenModal && (
+        <LeggTilBarnModal
+          tittel={intl.formatMessage({ id: 'barnadine.leggtil' })}
+          lukkModal={() => settÅpenModal(false)}
+          barneListe={barneliste}
+          settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+          oppdaterBarnISøknaden={oppdaterBarnISøknaden}
+        />
+      )}
+    </BarnaDineContainer>
+  );
+};

--- a/src/barnetilsyn/steg/3-barnadine/BarneConfig.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarneConfig.tsx
@@ -1,0 +1,29 @@
+import { ISpørsmål } from '../../../models/felles/spørsmålogsvar';
+import { EBarn } from '../../../models/steg/barn';
+import { JaNeiSvar, JaSvar, NeiSvar } from '../../../helpers/svar';
+import { IDokumentasjon } from '../../../models/steg/dokumentasjon';
+import { DokumentasjonsConfig } from '../../DokumentasjonsConfig';
+import { LokalIntlShape } from '../../../language/typer';
+
+// --- Dokumentasjon
+const Terminbekreftelse: IDokumentasjon =
+  DokumentasjonsConfig.Terminbekreftelse;
+
+// --- Spørsmål
+
+export const barnetFødt = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EBarn.født,
+  tekstid: 'barnekort.spm.født',
+  flersvar: false,
+  svaralternativer: [
+    JaSvar(intl),
+    { ...NeiSvar(intl), dokumentasjonsbehov: Terminbekreftelse },
+  ],
+});
+
+export const skalBarnetBoHosSøker = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EBarn.skalBarnetBoHosSøker,
+  tekstid: 'barnekort.spm.skalBarnetBoHosSøker',
+  flersvar: false,
+  svaralternativer: JaNeiSvar(intl),
+});

--- a/src/barnetilsyn/steg/3-barnadine/Barnekort.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/Barnekort.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import barn1 from '../../../assets/barn1.svg';
+import barn2 from '../../../assets/barn2.svg';
+import barn3 from '../../../assets/barn3.svg';
+import ufødtIkon from '../../../assets/ufodt.svg';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { hentTekst } from '../../../utils/søknad';
+import { IBarn } from '../../../models/steg/barn';
+import { formatDate, strengTilDato } from '../../../utils/dato';
+import { Heading } from '@navikt/ds-react';
+import styled from 'styled-components';
+import { InformasjonsElement } from './BarnekortInformasjonsElement';
+
+interface Props {
+  gjeldendeBarn: IBarn;
+  footer: React.ReactNode;
+}
+
+const Container = styled.div`
+  width: 276px;
+  background-color: #e7e9e9;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: flex-end;
+  height: 128px;
+  justify-content: center;
+  background-color: #4d3e55;
+  border-bottom: 4px solid #826ba1;
+`;
+
+const Innhold = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem 2rem;
+  text-align: center;
+`;
+
+const Barnekort: React.FC<Props> = ({ gjeldendeBarn, footer }) => {
+  const intl = useLokalIntlContext();
+
+  const {
+    navn,
+    fødselsdato,
+    født,
+    ident,
+    alder,
+    lagtTil,
+    harSammeAdresse,
+    medforelder,
+    harAdressesperre,
+  } = gjeldendeBarn;
+
+  const formatFnr = (fødselsnummer: string) => {
+    return fødselsnummer.substring(0, 6) + ' ' + fødselsnummer.substring(6, 11);
+  };
+
+  const ikoner = [barn1, barn2, barn3];
+  const ikon = født?.verdi
+    ? ikoner[Math.floor(Math.random() * ikoner.length)]
+    : ufødtIkon;
+
+  let bosted: string = '';
+
+  if (lagtTil) {
+    bosted = født?.verdi
+      ? harSammeAdresse.verdi
+        ? hentTekst('barnekort.adresse.bor', intl)
+        : hentTekst('barnekort.adresse.borIkke', intl)
+      : harSammeAdresse.verdi
+        ? hentTekst('barnekort.adresse.skalBo', intl)
+        : hentTekst('barnekort.adresse.skalIkkeBo', intl);
+  } else {
+    bosted = harSammeAdresse.verdi
+      ? intl.formatMessage({ id: 'barnekort.adresse.registrert' })
+      : intl.formatMessage({ id: 'barnekort.adresse.uregistrert' });
+  }
+
+  return (
+    <Container>
+      <Header>
+        <img alt="barn" src={ikon} />
+      </Header>
+      <Innhold>
+        <Heading size="small" level="3">
+          {navn.verdi
+            ? navn.verdi
+            : intl.formatMessage({ id: 'barnekort.normaltekst.barn' })}
+        </Heading>
+        {!harAdressesperre &&
+          (ident.verdi ? (
+            <InformasjonsElement
+              forklaringId={'barnekort.fødselsnummer'}
+              verdi={formatFnr(ident.verdi)}
+            />
+          ) : (
+            <InformasjonsElement
+              forklaringId={
+                født?.verdi ? 'barnekort.fødselsdato' : 'barnekort.termindato'
+              }
+              verdi={formatDate(strengTilDato(fødselsdato.verdi))}
+            />
+          ))}
+        <InformasjonsElement
+          forklaringId={'barnekort.alder'}
+          verdi={
+            født?.verdi
+              ? alder.verdi + ' ' + intl.formatMessage({ id: 'barnekort.år' })
+              : hentTekst('barnekort.erUfødt', intl)
+          }
+        />
+        {!harAdressesperre && (
+          <InformasjonsElement
+            forklaringId={'barnekort.bosted'}
+            verdi={bosted}
+          />
+        )}
+        {medforelder &&
+          (medforelder.verdi?.navn || medforelder.verdi?.alder) && (
+            <InformasjonsElement
+              forklaringId={'barnasbosted.forelder.annen'}
+              verdi={
+                medforelder?.verdi && medforelder?.verdi.navn
+                  ? medforelder?.verdi?.navn
+                  : medforelder?.verdi?.alder
+                    ? `${hentTekst('barnekort.medforelder.hemmelig', intl)}, ${
+                        medforelder.verdi.alder
+                      }`
+                    : null
+              }
+            />
+          )}
+        {footer}
+      </Innhold>
+    </Container>
+  );
+};
+
+export default Barnekort;

--- a/src/barnetilsyn/steg/3-barnadine/BarnekortInformasjonsElement.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/BarnekortInformasjonsElement.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { BodyShort, Label } from '@navikt/ds-react';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+
+export const InformasjonsElement: React.FC<{
+  forklaringId: string;
+  verdi: string | null;
+}> = ({ forklaringId, verdi }) => {
+  const intl = useLokalIntlContext();
+
+  return (
+    <div>
+      <Label size="small">{intl.formatMessage({ id: forklaringId })}</Label>
+      <BodyShort>{verdi}</BodyShort>
+    </div>
+  );
+};

--- a/src/barnetilsyn/steg/3-barnadine/EndreEllerSlettBarn.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/EndreEllerSlettBarn.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { Button } from '@navikt/ds-react';
+import { IBarn } from '../../../models/steg/barn';
+import { SettDokumentasjonsbehovBarn } from '../../../models/søknad/søknad';
+import LeggTilBarnModal from './LeggTilBarnModal';
+
+interface Props {
+  fjernBarnFraSøknad: (id: string) => void;
+  id: string;
+  settDokumentasjonsbehovForBarn: SettDokumentasjonsbehovBarn;
+  barneListe: IBarn[];
+  oppdaterBarnISøknaden: (oppdatertBarn: IBarn) => void;
+}
+
+const LenkeContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+`;
+
+export const EndreEllerSlettBarn: React.FC<Props> = ({
+  fjernBarnFraSøknad,
+  id,
+  settDokumentasjonsbehovForBarn,
+  barneListe,
+  oppdaterBarnISøknaden,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const [åpenEndreModal, settÅpenEndreModal] = useState(false);
+
+  return (
+    <>
+      <LenkeContainer>
+        <Button variant="secondary" onClick={() => settÅpenEndreModal(true)}>
+          {intl.formatMessage({ id: 'barnekort.lenke.endre' })}
+        </Button>
+        <Button variant="tertiary" onClick={() => fjernBarnFraSøknad(id)}>
+          {intl.formatMessage({ id: 'barnekort.fjern' })}
+        </Button>
+      </LenkeContainer>
+
+      {åpenEndreModal && (
+        <LeggTilBarnModal
+          tittel={intl.formatMessage({ id: 'barnadine.endre' })}
+          lukkModal={() => settÅpenEndreModal(false)}
+          id={id}
+          barneListe={barneListe}
+          settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+          oppdaterBarnISøknaden={oppdaterBarnISøknaden}
+        />
+      )}
+    </>
+  );
+};

--- a/src/barnetilsyn/steg/3-barnadine/LeggTilBarnKort.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/LeggTilBarnKort.tsx
@@ -1,0 +1,33 @@
+import { BodyShort, Button } from '@navikt/ds-react';
+import { hentTekst } from '../../../utils/søknad';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import styled from 'styled-components';
+import React from 'react';
+
+const BarnekortContainer = styled.div`
+  width: 276px;
+  background-color: #e7e9e9;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  padding: 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  align-items: center;
+  height: fit-content;
+`;
+
+export const LeggTilBarnKort: React.FC<{
+  settÅpenModal: (åpen: React.SetStateAction<boolean>) => void;
+}> = ({ settÅpenModal }) => {
+  const intl = useLokalIntlContext();
+
+  return (
+    <BarnekortContainer>
+      <BodyShort as="p">{hentTekst('barnadine.leggtil.info', intl)}</BodyShort>
+      <Button variant="secondary" onClick={() => settÅpenModal(true)}>
+        {hentTekst('barnadine.leggtil', intl)}
+      </Button>
+    </BarnekortContainer>
+  );
+};

--- a/src/barnetilsyn/steg/3-barnadine/LeggTilBarnModal.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/LeggTilBarnModal.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import LeggTilBarnUfødt from './LeggTilBarnUfødt';
+import Seksjonsgruppe from '../../../components/gruppe/SeksjonGruppe';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { IBarn } from '../../../models/steg/barn';
+import { hentNyttBarn } from '../../../helpers/steg/barn';
+import { ESvar } from '../../../models/felles/spørsmålogsvar';
+import LocaleTekst from '../../../language/LocaleTekst';
+import { Button } from '@navikt/ds-react';
+import { SettDokumentasjonsbehovBarn } from '../../../models/søknad/søknad';
+import { styled } from 'styled-components';
+import { ModalWrapper } from '../../../components/Modal/ModalWrapper';
+import { barnetFødt } from './BarneConfig';
+
+interface Props {
+  tittel: string;
+  lukkModal: () => void;
+  id?: string;
+  settDokumentasjonsbehovForBarn: SettDokumentasjonsbehovBarn;
+  barneListe: IBarn[];
+  oppdaterBarnISøknaden: (oppdatertBarn: IBarn) => void;
+}
+
+const StyledSeksjonsgruppe = styled(Seksjonsgruppe)`
+  min-height: 500px;
+  width: 450px;
+  padding: 2rem 2.5rem;
+
+  @media (max-width: 767px) {
+    width: auto;
+    padding: 2rem 0;
+  }
+`;
+
+const LeggTilBarnModal: React.FC<Props> = ({
+  tittel,
+  lukkModal,
+  id,
+  barneListe,
+  settDokumentasjonsbehovForBarn,
+  oppdaterBarnISøknaden,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const [barnDato, settBarnDato] = useState<string>('');
+  const [født, settBarnFødt] = useState<boolean>();
+  const [navn, settNavn] = useState('');
+  const [ident, settIdent] = useState<string>('');
+  const [boHosDeg, settBoHosDeg] = useState<string>('');
+  const [skalHaBarnepass, settSkalHaBarnepass] = useState<boolean | undefined>(
+    true
+  );
+  const barnetFødtSpm = barnetFødt(intl);
+
+  useEffect(() => {
+    if (id) {
+      const detteBarnet = barneListe.find((b) => b.id === id);
+
+      settNavn(detteBarnet?.navn?.verdi ? detteBarnet.navn.verdi : '');
+      settIdent(detteBarnet?.ident?.verdi ? detteBarnet.ident.verdi : '');
+      settBarnFødt(detteBarnet?.født?.verdi);
+      settBoHosDeg(detteBarnet?.harSammeAdresse?.verdi ? ESvar.JA : ESvar.NEI);
+      settSkalHaBarnepass(detteBarnet?.skalHaBarnepass?.verdi);
+      detteBarnet?.fødselsdato.verdi &&
+        settDato(detteBarnet.fødselsdato?.verdi);
+    }
+    // eslint-disable-next-line
+  }, []);
+
+  const settDato = (date: string): void => {
+    date && settBarnDato(date);
+  };
+
+  const settBo = (nyttBo: string) => {
+    settBoHosDeg(nyttBo);
+  };
+
+  const leggTilEllerEndreBarn = (id: string | undefined) => {
+    const nyttBarn: IBarn = hentNyttBarn(
+      id,
+      ident,
+      barnDato,
+      navn,
+      boHosDeg,
+      født ? født : false,
+      intl,
+      skalHaBarnepass
+    );
+
+    const erBarnFødtSvar = barnetFødtSpm.svaralternativer.find(
+      (svar) => svar.id === ESvar.NEI
+    );
+    erBarnFødtSvar &&
+      settDokumentasjonsbehovForBarn(
+        barnetFødtSpm,
+        erBarnFødtSvar,
+        nyttBarn.id
+      );
+
+    oppdaterBarnISøknaden(nyttBarn);
+
+    lukkModal();
+  };
+
+  return (
+    <ModalWrapper tittel={tittel} visModal={true} onClose={lukkModal}>
+      <StyledSeksjonsgruppe aria-live="polite">
+        <KomponentGruppe>
+          <LeggTilBarnUfødt
+            settBo={settBo}
+            boHosDeg={boHosDeg}
+            settDato={settDato}
+            barnDato={barnDato}
+          />
+        </KomponentGruppe>
+        {boHosDeg && (
+          <Button
+            variant="primary"
+            aria-live="polite"
+            onClick={() => leggTilEllerEndreBarn(id)}
+          >
+            <LocaleTekst tekst={'barnadine.leggtil'} />
+          </Button>
+        )}
+      </StyledSeksjonsgruppe>
+    </ModalWrapper>
+  );
+};
+
+export default LeggTilBarnModal;

--- a/src/barnetilsyn/steg/3-barnadine/LeggTilBarnUfødt.tsx
+++ b/src/barnetilsyn/steg/3-barnadine/LeggTilBarnUfødt.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { ESvar, ESvarTekstid } from '../../../models/felles/spørsmålogsvar';
+import { hentTekst } from '../../../utils/søknad';
+import AlertStripeDokumentasjon from '../../../components/AlertstripeDokumentasjon';
+import { erDatoGyldigOgInnaforBegrensninger } from '../../../components/dato/utils';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import FormattedMessage from '../../../language/FormattedMessage';
+import { Alert, RadioGroup } from '@navikt/ds-react';
+import styled from 'styled-components';
+import {
+  Datovelger,
+  DatoBegrensning,
+} from '../../../components/dato/Datovelger';
+import RadioPanelCustom from '../../../components/panel/RadioPanel';
+
+interface Props {
+  settBo: (nyttBo: string) => void;
+  boHosDeg: string;
+  settDato: (date: string) => void;
+  barnDato: string;
+}
+
+const RadiopanelWrapper = styled.div`
+  .navds-fieldset .navds-radio-buttons {
+    margin-top: 0;
+  }
+  .navds-radio-buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: min-content;
+    grid-gap: 1rem;
+    padding-top: 1rem;
+
+    @media all and (max-width: 767px) {
+      grid-template-columns: 1fr;
+    }
+  }
+`;
+
+const LeggTilBarnUfødt: React.FC<Props> = ({
+  settBo,
+  boHosDeg,
+  settDato,
+  barnDato,
+}) => {
+  const intl = useLokalIntlContext();
+
+  return (
+    <>
+      <KomponentGruppe>
+        <Datovelger
+          settDato={(e) => settDato(e)}
+          valgtDato={barnDato}
+          tekstid={'barnadine.termindato'}
+          datobegrensning={DatoBegrensning.FremtidigeDatoer}
+        />
+        <AlertStripeDokumentasjon>
+          <FormattedMessage id="barnadine.info.terminbekreftelse" />
+        </AlertStripeDokumentasjon>
+      </KomponentGruppe>
+      {barnDato &&
+        erDatoGyldigOgInnaforBegrensninger(
+          barnDato,
+          DatoBegrensning.FremtidigeDatoer
+        ) && (
+          <KomponentGruppe>
+            <RadiopanelWrapper>
+              <RadioGroup
+                legend={intl.formatMessage({
+                  id: 'barnekort.spm.skalBarnetBoHosSøker',
+                })}
+                value={boHosDeg}
+              >
+                <RadioPanelCustom
+                  key={ESvar.JA}
+                  name={'radio-bosted'}
+                  value={ESvar.JA}
+                  checked={boHosDeg === ESvar.JA}
+                  onChange={(e) => settBo(e.target.value)}
+                >
+                  {hentTekst(ESvarTekstid.JA, intl)}
+                </RadioPanelCustom>
+                <RadioPanelCustom
+                  key={ESvar.NEI}
+                  name={'radio-bosted'}
+                  value={ESvar.NEI}
+                  checked={boHosDeg === ESvar.NEI}
+                  onChange={(e) => settBo(e.target.value)}
+                >
+                  {hentTekst(ESvarTekstid.NEI, intl)}
+                </RadioPanelCustom>
+              </RadioGroup>
+            </RadiopanelWrapper>
+            {boHosDeg === ESvar.NEI && (
+              <Alert size="small" variant="warning" inline>
+                <FormattedMessage id="barnadine.advarsel.skalikkebo" />
+              </Alert>
+            )}
+          </KomponentGruppe>
+        )}
+    </>
+  );
+};
+
+export default LeggTilBarnUfødt;

--- a/src/barnetilsyn/steg/4-barnasbosted/AnnenForelderKnapper.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/AnnenForelderKnapper.tsx
@@ -1,0 +1,153 @@
+import React, { SyntheticEvent } from 'react';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { IBarn } from '../../../models/steg/barn';
+import { IForelder } from '../../../models/steg/forelder';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { harValgtSvar } from '../../../utils/spørsmålogsvar';
+import {
+  hentBarnetsNavnEllerBeskrivelse,
+  lagtTilAnnenForelderId,
+} from '../../../utils/barn';
+import { hentUid } from '../../../utils/autentiseringogvalidering/uuid';
+import RadioPanelCustom from '../../../components/panel/RadioPanel';
+import { RadioGroup } from '@navikt/ds-react';
+import styled from 'styled-components';
+
+interface Props {
+  barn: IBarn;
+  forelder: IForelder;
+  oppdaterAnnenForelder: (annenForelderId: string) => void;
+  førsteBarnTilHverForelder?: IBarn[];
+  settBarnHarSammeForelder: React.Dispatch<
+    React.SetStateAction<boolean | undefined>
+  >;
+  settForelder: (verdi: IForelder) => void;
+  oppdaterBarn: (barn: IBarn, erFørsteAvflereBarn: boolean) => void;
+}
+
+const StyledAnnenForelderSpørsmål = styled.div`
+  legend {
+    display: none;
+  }
+  .navds-fieldset .navds-radio-buttons {
+    margin-top: 0;
+  }
+  .navds-radio-buttons {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-auto-rows: min-content;
+    grid-gap: 1rem;
+    padding-top: 1rem;
+  }
+`;
+const AnnenForelderKnapper: React.FC<Props> = ({
+  barn,
+  forelder,
+  oppdaterAnnenForelder,
+  førsteBarnTilHverForelder,
+  settBarnHarSammeForelder,
+  settForelder,
+  oppdaterBarn,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const leggTilSammeForelder = (
+    e: SyntheticEvent<EventTarget, Event>,
+    detAndreBarnet: IBarn
+  ) => {
+    settBarnHarSammeForelder(true);
+    const oppdatertForelder = structuredClone(detAndreBarnet.forelder);
+
+    oppdaterAnnenForelder(detAndreBarnet.id);
+
+    settForelder({
+      ...barn.forelder,
+      id: oppdatertForelder?.id,
+      navn: oppdatertForelder?.navn,
+      fødselsdato: oppdatertForelder?.fødselsdato,
+      ident: oppdatertForelder?.ident,
+      borINorge: oppdatertForelder?.borINorge,
+      borAnnenForelderISammeHus: oppdatertForelder?.borAnnenForelderISammeHus,
+      borAnnenForelderISammeHusBeskrivelse:
+        oppdatertForelder?.borAnnenForelderISammeHusBeskrivelse,
+      boddSammenFør: oppdatertForelder?.boddSammenFør,
+      flyttetFra: oppdatertForelder?.flyttetFra,
+      hvorMyeSammen: oppdatertForelder?.hvorMyeSammen,
+      beskrivSamværUtenBarn: oppdatertForelder?.beskrivSamværUtenBarn,
+      land: oppdatertForelder?.land,
+      fraFolkeregister: oppdatertForelder?.fraFolkeregister,
+      skalBarnetBoHosSøker: forelder.skalBarnetBoHosSøker,
+    });
+  };
+
+  const leggTilAnnenForelder = () => {
+    settBarnHarSammeForelder(false);
+    const id = hentUid();
+
+    const annenForelder =
+      !barn.harSammeAdresse.verdi &&
+      harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)
+        ? {
+            skalBarnetBoHosSøker: forelder.skalBarnetBoHosSøker,
+            id,
+          }
+        : { id };
+
+    oppdaterBarn(
+      {
+        ...barn,
+        annenForelderId: lagtTilAnnenForelderId,
+        forelder: annenForelder,
+      },
+      false
+    );
+    settForelder(annenForelder);
+  };
+
+  const andreForelder = 'andre-forelder-';
+  const andreForelderAnnen = 'andre-forelder-annen';
+
+  if (!førsteBarnTilHverForelder) return null;
+
+  return (
+    <KomponentGruppe>
+      <StyledAnnenForelderSpørsmål>
+        <RadioGroup legend={null} value={barn.annenForelderId}>
+          {førsteBarnTilHverForelder.map((barn) => {
+            if (
+              !barn.forelder?.borINorge &&
+              !barn.forelder?.kanIkkeOppgiAnnenForelderFar
+            )
+              return null;
+
+            return (
+              <RadioPanelCustom
+                key={`${andreForelder}${barn.id}`}
+                name={`${andreForelder}${barn.id}`}
+                value={barn.id}
+                checked={barn.annenForelderId === barn.id}
+                onChange={(e) => leggTilSammeForelder(e, barn)}
+              >{`${intl.formatMessage({
+                id: 'barnasbosted.forelder.sammesom',
+              })} ${hentBarnetsNavnEllerBeskrivelse(
+                barn,
+                intl
+              )}`}</RadioPanelCustom>
+            );
+          })}
+          <RadioPanelCustom
+            key={andreForelderAnnen}
+            name={`${andreForelder}${barn.navn}`}
+            value={lagtTilAnnenForelderId}
+            checked={barn.annenForelderId === lagtTilAnnenForelderId}
+            onChange={() => leggTilAnnenForelder()}
+          >
+            {intl.formatMessage({ id: 'barnasbosted.forelder.annen' })}
+          </RadioPanelCustom>
+        </RadioGroup>
+      </StyledAnnenForelderSpørsmål>
+    </KomponentGruppe>
+  );
+};
+
+export default AnnenForelderKnapper;

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnasBosted.tsx
@@ -12,7 +12,7 @@ import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
 import { antallBarnMedForeldreUtfylt } from '../../../utils/barn';
 import { kommerFraOppsummeringen } from '../../../utils/locationState';
-import BarnasBostedInnhold from '../../../søknad/steg/4-barnasbosted/BarnasBostedInnhold';
+import BarnasBostedInnhold from './BarnasBostedInnhold';
 
 const BarnasBosted: React.FC = () => {
   const intl = useLokalIntlContext();

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -1,0 +1,160 @@
+import React, { RefObject, useEffect, useRef, useState } from 'react';
+import { hentTekst } from '../../../utils/søknad';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+
+import { IBarn } from '../../../models/steg/barn';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import BarneHeader from '../../../components/BarneHeader';
+import {
+  antallBarnMedForeldreUtfylt,
+  forelderidentMedBarn,
+  hentIndexFørsteBarnSomIkkeErUtfylt,
+  kopierFellesForeldreInformasjon,
+} from '../../../utils/barn';
+import { BodyShort } from '@navikt/ds-react';
+import {
+  ISøknad as SøknadOvergangsstønad,
+  SettDokumentasjonsbehovBarn,
+} from '../../../models/søknad/søknad';
+import { ISøknad as SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
+import { ISøknad as SøknadSkolepenger } from '../../../skolepenger/models/søknad';
+import BarnetsBostedEndre from './BarnetsBostedEndre';
+import BarnetsBostedLagtTil from './BarnetsBostedLagtTil';
+
+const scrollTilRef = (ref: RefObject<HTMLDivElement | null>) => {
+  if (!ref || !ref.current) return;
+  window.scrollTo({ top: ref.current!.offsetTop, left: 0, behavior: 'smooth' });
+};
+
+interface Props {
+  aktuelleBarn: IBarn[];
+  oppdaterBarnISøknaden: (oppdatertBarn: IBarn) => void;
+  oppdaterFlereBarnISøknaden: (oppdaterteBarn: IBarn[]) => void;
+  settDokumentasjonsbehovForBarn: SettDokumentasjonsbehovBarn;
+  sisteBarnUtfylt: boolean;
+  settSisteBarnUtfylt: React.Dispatch<React.SetStateAction<boolean>>;
+  søknad: SøknadOvergangsstønad | SøknadBarnetilsyn | SøknadSkolepenger;
+}
+
+const BarnasBostedInnhold: React.FC<Props> = ({
+  aktuelleBarn,
+  oppdaterBarnISøknaden,
+  oppdaterFlereBarnISøknaden,
+  settDokumentasjonsbehovForBarn,
+  sisteBarnUtfylt,
+  settSisteBarnUtfylt,
+  søknad,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const barnMedLevendeMedforelder = aktuelleBarn.filter(
+    (barn: IBarn) =>
+      !barn.medforelder?.verdi ||
+      (barn.medforelder?.verdi && barn.medforelder?.verdi?.død !== true)
+  );
+
+  const barnMedDødMedforelder = aktuelleBarn.filter((barn: IBarn) => {
+    return barn.medforelder?.verdi?.død === true;
+  });
+
+  const antallBarnMedForeldre = antallBarnMedForeldreUtfylt(
+    barnMedLevendeMedforelder
+  );
+
+  const [aktivIndex, settAktivIndex] = useState<number>(
+    hentIndexFørsteBarnSomIkkeErUtfylt(barnMedLevendeMedforelder)
+  );
+
+  const lagtTilBarn = useRef(null);
+
+  const scrollTilLagtTilBarn = () => {
+    setTimeout(() => scrollTilRef(lagtTilBarn), 120);
+  };
+
+  useEffect(() => {
+    settSisteBarnUtfylt(
+      antallBarnMedForeldreUtfylt(barnMedLevendeMedforelder) ===
+        barnMedLevendeMedforelder.length
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [søknad]);
+  const forelderIdenterMedBarn = forelderidentMedBarn(
+    barnMedLevendeMedforelder
+  );
+
+  const oppdaterBarnMedNyForelderInformasjon = (
+    oppdatertBarn: IBarn,
+    skalKopiereForeldreinformasjonTilAndreBarn: boolean
+  ) => {
+    const barnMedSammeForelder =
+      oppdatertBarn.forelder?.ident?.verdi &&
+      forelderIdenterMedBarn.get(oppdatertBarn.forelder?.ident?.verdi);
+
+    if (skalKopiereForeldreinformasjonTilAndreBarn && barnMedSammeForelder) {
+      oppdaterFlereBarnISøknaden(
+        barnMedSammeForelder.map((b) => {
+          if (b.id === oppdatertBarn.id) {
+            return oppdatertBarn;
+          }
+
+          return oppdatertBarn.forelder
+            ? kopierFellesForeldreInformasjon(b, oppdatertBarn.forelder)
+            : b;
+        })
+      );
+    } else {
+      oppdaterBarnISøknaden(oppdatertBarn);
+    }
+  };
+
+  return (
+    <>
+      {barnMedLevendeMedforelder.map((barn: IBarn, index: number) => {
+        const key = barn.fødselsdato.verdi + index;
+        if (index === aktivIndex) {
+          return (
+            <BarnetsBostedEndre
+              barn={barn}
+              settSisteBarnUtfylt={settSisteBarnUtfylt}
+              settAktivIndex={settAktivIndex}
+              aktivIndex={aktivIndex}
+              key={key}
+              scrollTilLagtTilBarn={scrollTilLagtTilBarn}
+              settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+              oppdaterBarnISøknaden={oppdaterBarnMedNyForelderInformasjon}
+              barneListe={søknad.person.barn}
+              forelderidenterMedBarn={forelderIdenterMedBarn}
+              søknad={søknad}
+            />
+          );
+        } else {
+          return (
+            <React.Fragment key={barn.id}>
+              {index + 1 === antallBarnMedForeldre && (
+                <div ref={lagtTilBarn} key={barn.id + '-ref'} />
+              )}
+              <BarnetsBostedLagtTil
+                barn={barn}
+                settAktivIndex={settAktivIndex}
+                index={index}
+                key={barn.id}
+                settSisteBarnUtfylt={settSisteBarnUtfylt}
+              />
+            </React.Fragment>
+          );
+        }
+      })}
+      {sisteBarnUtfylt &&
+        barnMedDødMedforelder.map((barn: IBarn) => (
+          <SeksjonGruppe key={barn.id}>
+            <BarneHeader barn={barn} />
+            <BodyShort style={{ textAlign: 'center', marginTop: '2rem' }}>
+              {hentTekst('barnasbosted.kanGåVidere', intl)}
+            </BodyShort>
+          </SeksjonGruppe>
+        ))}
+    </>
+  );
+};
+
+export default BarnasBostedInnhold;

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnetsAndreForelderTittel.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnetsAndreForelderTittel.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { førsteBokstavStor } from '../../../utils/språk';
+import { hentBarnNavnEllerBarnet } from '../../../utils/barn';
+import { hentTekst } from '../../../utils/søknad';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import { IBarn } from '../../../models/steg/barn';
+import { FC } from 'react';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { Heading } from '@navikt/ds-react';
+
+const BarnetsAndreForelderTittel: FC<{ barn: IBarn }> = ({ barn }) => {
+  const intl = useLokalIntlContext();
+  return (
+    <FeltGruppe>
+      <Heading size="small" level="4">
+        {førsteBokstavStor(
+          hentBarnNavnEllerBarnet(barn, 'barnasbosted.element.barnet', intl)
+        )}
+        {hentTekst('barnasbosted.element.andreforelder', intl)}
+      </Heading>
+    </FeltGruppe>
+  );
+};
+export default BarnetsAndreForelderTittel;

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -1,0 +1,316 @@
+import React, { useState } from 'react';
+import AnnenForelderKnapper from './AnnenForelderKnapper';
+import BarneHeader from '../../../components/BarneHeader';
+import BostedOgSamvær from './bostedOgSamvær/BostedOgSamvær';
+import OmAndreForelder from './OmAndreForelder';
+import SkalBarnetBoHosSøker from './SkalBarnetBoHosSøker';
+import { IBarn } from '../../../models/steg/barn';
+import { IForelder } from '../../../models/steg/forelder';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { harValgtSvar } from '../../../utils/spørsmålogsvar';
+import { erBarnetilsynSøknad, hentTekst } from '../../../utils/søknad';
+import {
+  erForelderUtfylt,
+  utfyltBorINorge,
+  visSpørsmålHvisIkkeSammeForelder,
+} from '../../../helpers/steg/forelder';
+import BorForelderINorge from './bostedOgSamvær/BorForelderINorge';
+import BorAnnenForelderISammeHus from './ikkesammeforelder/BorAnnenForelderISammeHus';
+import BoddSammenFør from './ikkesammeforelder/BoddSammenFør';
+import HvorMyeSammen from './ikkesammeforelder/HvorMyeSammen';
+import { hentUid } from '../../../utils/autentiseringogvalidering/uuid';
+import { erGyldigDato } from '../../../utils/dato';
+import { TypeBarn } from '../../../models/steg/barnasbosted';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import BarnetsAndreForelderTittel from './BarnetsAndreForelderTittel';
+import LocaleTekst from '../../../language/LocaleTekst';
+import { Alert, BodyShort, Button, Label } from '@navikt/ds-react';
+import {
+  ISøknad as SøknadOvergangsstønad,
+  SettDokumentasjonsbehovBarn,
+} from '../../../models/søknad/søknad';
+import styled from 'styled-components';
+import {
+  finnFørsteBarnTilHverForelder,
+  finnTypeBarnForMedForelder,
+  harValgtBorISammeHus,
+  skalBorAnnenForelderINorgeVises,
+  skalAnnenForelderRedigeres,
+} from '../../../helpers/steg/barnetsBostedEndre';
+import { stringHarVerdiOgErIkkeTom } from '../../../utils/typer';
+import { ISøknad as SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
+import { ISøknad as SøknadSkolepenger } from '../../../skolepenger/models/søknad';
+
+const AlertMedTopMargin = styled(Alert)`
+  margin-top: 1rem;
+`;
+
+const visBostedOgSamværSeksjon = (
+  forelder: IForelder,
+  visesBorINorgeSpørsmål: boolean
+) => {
+  return visesBorINorgeSpørsmål
+    ? utfyltBorINorge(forelder)
+    : erGyldigDato(forelder.fødselsdato?.verdi);
+};
+
+interface Props {
+  barn: IBarn;
+  settAktivIndex: React.Dispatch<React.SetStateAction<number>>;
+  aktivIndex: number;
+  settSisteBarnUtfylt: (sisteBarnUtfylt: boolean) => void;
+  scrollTilLagtTilBarn: () => void;
+  settDokumentasjonsbehovForBarn: SettDokumentasjonsbehovBarn;
+  barneListe: IBarn[];
+  oppdaterBarnISøknaden: (endretBarn: IBarn, erFørstebarn: boolean) => void;
+  forelderidenterMedBarn: Map<string, IBarn[]>;
+  søknad: SøknadOvergangsstønad | SøknadBarnetilsyn | SøknadSkolepenger;
+}
+
+const BarnetsBostedEndre: React.FC<Props> = ({
+  barn,
+  settAktivIndex,
+  aktivIndex,
+  settSisteBarnUtfylt,
+  scrollTilLagtTilBarn,
+  barneListe,
+  oppdaterBarnISøknaden,
+  settDokumentasjonsbehovForBarn,
+  forelderidenterMedBarn,
+  søknad,
+}) => {
+  const intl = useLokalIntlContext();
+  const [forelder, settForelder] = useState<IForelder>(
+    barn.forelder
+      ? {
+          ...barn.forelder,
+          kanIkkeOppgiAnnenForelderFar: {
+            label: hentTekst('barnasbosted.kanikkeoppgiforelder', intl),
+            verdi: barn.forelder.kanIkkeOppgiAnnenForelderFar?.verdi || false,
+          },
+        }
+      : {
+          id: hentUid(),
+        }
+  );
+
+  const [kjennerIkkeIdent, settKjennerIkkeIdent] = useState<boolean>(
+    stringHarVerdiOgErIkkeTom(forelder.navn?.verdi) &&
+      !stringHarVerdiOgErIkkeTom(forelder.ident?.verdi)
+  );
+
+  const { boddSammenFør, flyttetFra, fødselsdato, ident } = forelder;
+
+  const harForelderFraPdl =
+    stringHarVerdiOgErIkkeTom(barn?.medforelder?.verdi?.navn) ||
+    barn?.medforelder?.verdi?.harAdressesperre === true;
+
+  const førsteBarnTilHverForelder = finnFørsteBarnTilHverForelder(
+    barneListe,
+    barn
+  );
+
+  const typeBarn = finnTypeBarnForMedForelder(barn, forelderidenterMedBarn);
+
+  const [barnHarSammeForelder, settBarnHarSammeForelder] = useState<
+    boolean | undefined
+  >(
+    typeBarn === TypeBarn.BARN_MED_KOPIERT_FORELDERINFORMASJON
+      ? true
+      : undefined
+  );
+
+  const leggTilForelder = () => {
+    oppdaterBarnISøknaden(
+      { ...barn, forelder: forelder },
+      typeBarn === TypeBarn.BARN_MED_OPPRINNELIG_FORELDERINFORMASJON
+    );
+
+    const nyIndex = aktivIndex + 1;
+    settAktivIndex(nyIndex);
+    scrollTilLagtTilBarn();
+  };
+
+  const leggTilAnnenForelderId = (annenForelderId: string) => {
+    oppdaterBarnISøknaden(
+      { ...barn, annenForelderId: annenForelderId },
+      typeBarn === TypeBarn.BARN_MED_OPPRINNELIG_FORELDERINFORMASJON
+    );
+  };
+
+  const erBarnMedISøknad = (barn: IBarn): boolean => {
+    return !erBarnetilsynSøknad(søknad) || barn.skalHaBarnepass?.verdi === true;
+  };
+
+  const finnesBarnISøknadMedRegistrertAnnenForelder = barneListe.some(
+    (b) =>
+      erBarnMedISøknad(b) &&
+      b.medforelder?.verdi?.ident &&
+      b.medforelder?.verdi?.navn
+  );
+
+  const visAnnenForelderRedigering = skalAnnenForelderRedigeres(
+    barn,
+    førsteBarnTilHverForelder,
+    barnHarSammeForelder,
+    forelder,
+    finnesBarnISøknadMedRegistrertAnnenForelder
+  );
+
+  const visBorAnnenForelderINorge = skalBorAnnenForelderINorgeVises(
+    barn,
+    typeBarn,
+    barnHarSammeForelder,
+    forelder,
+    ident,
+    fødselsdato,
+    kjennerIkkeIdent
+  );
+
+  const skalFylleUtHarBoddSammenFør =
+    harValgtBorISammeHus(forelder) && utfyltBorINorge(forelder);
+
+  const skalViseAnnenForelderKnapperForGjenbruk =
+    barn.erFraForrigeSøknad &&
+    finnesBarnISøknadMedRegistrertAnnenForelder &&
+    !barn.medforelder?.verdi &&
+    !erForelderUtfylt(barn.harSammeAdresse, forelder, harForelderFraPdl);
+
+  const skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad =
+    barn.erFraForrigeSøknad !== true &&
+    finnesBarnISøknadMedRegistrertAnnenForelder &&
+    !barn.medforelder?.verdi;
+
+  const skalViseAnnenForelderKnapper =
+    skalViseAnnenForelderKnapperForGjenbruk ||
+    skalViseAnnenForelderKnapperForNyttBarnEllerFørstegangssøknad;
+
+  return (
+    <div className="barnas-bosted">
+      <SeksjonGruppe>
+        <BarneHeader barn={barn} />
+      </SeksjonGruppe>
+      <div className="barnas-bosted__innhold">
+        {!barn.harSammeAdresse.verdi && (
+          <SkalBarnetBoHosSøker
+            barn={barn}
+            forelder={forelder}
+            settForelder={settForelder}
+            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+          />
+        )}
+
+        {(barn.harSammeAdresse?.verdi ||
+          harValgtSvar(forelder.skalBarnetBoHosSøker?.verdi)) && (
+          <SeksjonGruppe>
+            <BarnetsAndreForelderTittel barn={barn} />
+
+            {skalViseAnnenForelderKnapper && (
+              <AnnenForelderKnapper
+                barn={barn}
+                forelder={forelder}
+                oppdaterAnnenForelder={leggTilAnnenForelderId}
+                førsteBarnTilHverForelder={førsteBarnTilHverForelder}
+                settBarnHarSammeForelder={settBarnHarSammeForelder}
+                settForelder={settForelder}
+                oppdaterBarn={oppdaterBarnISøknaden}
+              />
+            )}
+
+            {visAnnenForelderRedigering && (
+              <OmAndreForelder
+                settForelder={settForelder}
+                forelder={forelder}
+                kjennerIkkeIdent={kjennerIkkeIdent}
+                settKjennerIkkeIdent={settKjennerIkkeIdent}
+                settSisteBarnUtfylt={settSisteBarnUtfylt}
+              />
+            )}
+
+            {barn.medforelder?.verdi && (
+              <>
+                <Label as="p">{hentTekst('person.navn', intl)}</Label>
+                <BodyShort>
+                  {barn.medforelder.verdi.navn
+                    ? barn.medforelder.verdi.navn
+                    : `${hentTekst('barnekort.medforelder.hemmelig', intl)}, ${
+                        barn.medforelder.verdi.alder
+                      }`}
+                </BodyShort>
+              </>
+            )}
+
+            {barnHarSammeForelder && (
+              <AlertMedTopMargin variant={'info'} inline>
+                {hentTekst('barnasbosted.medforelder.gjenbrukt', intl)}
+              </AlertMedTopMargin>
+            )}
+          </SeksjonGruppe>
+        )}
+
+        {visBorAnnenForelderINorge && (
+          <BorForelderINorge
+            barn={barn}
+            forelder={forelder}
+            settForelder={settForelder}
+            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+          />
+        )}
+
+        {(visBostedOgSamværSeksjon(forelder, visBorAnnenForelderINorge) ||
+          barnHarSammeForelder) && (
+          <BostedOgSamvær
+            settForelder={settForelder}
+            forelder={forelder}
+            barn={barn}
+            settDokumentasjonsbehovForBarn={settDokumentasjonsbehovForBarn}
+          />
+        )}
+
+        {!barnHarSammeForelder &&
+          visSpørsmålHvisIkkeSammeForelder(forelder) && (
+            <>
+              {utfyltBorINorge(forelder) && (
+                <BorAnnenForelderISammeHus
+                  forelder={forelder}
+                  settForelder={settForelder}
+                  barn={barn}
+                />
+              )}
+
+              {skalFylleUtHarBoddSammenFør && (
+                <BoddSammenFør
+                  forelder={forelder}
+                  barn={barn}
+                  settForelder={settForelder}
+                />
+              )}
+
+              {((skalFylleUtHarBoddSammenFør &&
+                boddSammenFør?.verdi === false) ||
+                (skalFylleUtHarBoddSammenFør &&
+                  erGyldigDato(flyttetFra?.verdi))) && (
+                <HvorMyeSammen
+                  forelder={forelder}
+                  barn={barn}
+                  settForelder={settForelder}
+                />
+              )}
+            </>
+          )}
+
+        {erForelderUtfylt(
+          barn.harSammeAdresse,
+          forelder,
+          harForelderFraPdl
+        ) && (
+          <Button variant="secondary" onClick={leggTilForelder}>
+            <LocaleTekst tekst={'knapp.neste'} />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BarnetsBostedEndre;

--- a/src/barnetilsyn/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/BarnetsBostedLagtTil.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import BarneHeader from '../../../components/BarneHeader';
+import { formatDate, strengTilDato } from '../../../utils/dato';
+import endre from '../../../assets/endre.svg';
+import LenkeMedIkon from '../../../components/knapper/LenkeMedIkon';
+import { hentBeskjedMedNavn } from '../../../utils/språk';
+import { IBarn } from '../../../models/steg/barn';
+import { hentTekst } from '../../../utils/søknad';
+import { ESvarTekstid } from '../../../models/felles/spørsmålogsvar';
+import { harValgtSvar } from '../../../utils/spørsmålogsvar';
+import { Label, BodyShort } from '@navikt/ds-react';
+import { harVerdi } from '../../../utils/typer';
+
+interface Props {
+  barn: IBarn;
+  settAktivIndex: React.Dispatch<React.SetStateAction<number>>;
+  index: number;
+  settSisteBarnUtfylt: (sisteBarnUtfylt: boolean) => void;
+}
+
+const BarnetsBostedLagtTil: React.FC<Props> = ({
+  barn,
+  settAktivIndex,
+  index,
+  settSisteBarnUtfylt,
+}) => {
+  const forelder = barn.forelder;
+  const intl = useLokalIntlContext();
+  const barnetsNavn =
+    barn.navn && barn.navn.verdi !== ''
+      ? barn.navn.verdi
+      : hentTekst('barnet.storForBokstav', intl);
+
+  if (
+    !forelder ||
+    (!barn.forelder?.borINorge && !barn.forelder?.kanIkkeOppgiAnnenForelderFar)
+  )
+    return null;
+
+  const endreInformasjon = () => {
+    settAktivIndex(index);
+    settSisteBarnUtfylt(false);
+  };
+
+  return (
+    <div className="barnas-bosted-lagt-til">
+      <BarneHeader barn={barn} visBakgrunn={true} />
+      <div className="barnas-bosted-lagt-til__svar">
+        {(forelder.navn || forelder.kanIkkeOppgiAnnenForelderFar) && (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {barnetsNavn}
+              {intl.formatMessage({ id: 'barnasbosted.element.andreforelder' })}
+            </Label>
+            <BodyShort>
+              {forelder.navn?.verdi === 'Ikke oppgitt' &&
+              barn.erFraForrigeSøknad
+                ? hentTekst('barnasbosted.kanikkeoppgiforelder', intl)
+                : forelder.navn?.verdi
+                  ? forelder.navn?.verdi
+                  : hentTekst('barnasbosted.kanikkeoppgiforelder', intl)}
+            </BodyShort>
+          </div>
+        )}
+        {forelder.hvorforIkkeOppgi && (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({ id: 'barnasbosted.spm.hvorforikkeoppgi' })
+              )}
+            </Label>
+            <BodyShort>
+              {forelder.ikkeOppgittAnnenForelderBegrunnelse
+                ? forelder.ikkeOppgittAnnenForelderBegrunnelse?.verdi
+                : hentTekst('barnasbosted.spm.donorbarn', intl)}
+            </BodyShort>
+          </div>
+        )}
+        {harValgtSvar(forelder.fødselsdato?.verdi) && forelder.fødselsdato && (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {intl.formatMessage({ id: 'datovelger.fødselsdato' })}
+            </Label>
+            <BodyShort>
+              {formatDate(strengTilDato(forelder.fødselsdato.verdi))}
+            </BodyShort>
+          </div>
+        )}
+        {!forelder.fraFolkeregister && forelder.ident && (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {intl.formatMessage({ id: 'person.ident.visning' })}
+            </Label>
+            <BodyShort>{forelder.ident.verdi}</BodyShort>
+          </div>
+        )}
+        {forelder.borINorge && (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({ id: 'barnasbosted.borinorge' })
+              )}
+            </Label>
+            <BodyShort>
+              {forelder.borINorge?.verdi
+                ? hentTekst(ESvarTekstid.JA, intl)
+                : hentTekst(ESvarTekstid.NEI, intl)}
+            </BodyShort>
+          </div>
+        )}
+        {forelder.land && (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {intl.formatMessage({ id: 'barnasbosted.hvilketLand' })}
+            </Label>
+            <BodyShort>{forelder.land?.verdi}</BodyShort>
+          </div>
+        )}
+        {forelder.harAnnenForelderSamværMedBarn?.verdi && (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({
+                  id: 'barnasbosted.spm.harAnnenForelderSamværMedBarn',
+                })
+              )}
+            </Label>
+            <BodyShort>
+              {forelder.harAnnenForelderSamværMedBarn?.verdi || ''}
+            </BodyShort>
+          </div>
+        )}
+        {forelder.harDereSkriftligSamværsavtale?.verdi ? (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({
+                  id: 'barnasbosted.spm.harDereSkriftligSamværsavtale',
+                })
+              )}
+            </Label>
+            <BodyShort>
+              {forelder.harDereSkriftligSamværsavtale.verdi}
+            </BodyShort>
+          </div>
+        ) : null}
+        {forelder.hvordanPraktiseresSamværet?.verdi ? (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {intl.formatMessage({ id: 'barnasbosted.element.samvær' })}
+            </Label>
+            <BodyShort>{forelder.hvordanPraktiseresSamværet.verdi}</BodyShort>
+          </div>
+        ) : null}
+        {forelder.borAnnenForelderISammeHus ? (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({
+                  id: 'barnasbosted.spm.borAnnenForelderISammeHus',
+                })
+              )}
+            </Label>
+            <BodyShort>{forelder.borAnnenForelderISammeHus.verdi}</BodyShort>
+          </div>
+        ) : null}
+        {harVerdi(forelder?.boddSammenFør?.verdi) ? (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({
+                  id: 'barnasbosted.spm.boddsammenfør',
+                })
+              )}
+            </Label>
+            <BodyShort>
+              {forelder.boddSammenFør?.verdi
+                ? hentTekst(ESvarTekstid.JA, intl)
+                : hentTekst(ESvarTekstid.NEI, intl)}
+            </BodyShort>
+          </div>
+        ) : null}
+        {forelder?.flyttetFra?.verdi ? (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({
+                  id: 'barnasbosted.normaltekst.nårflyttetfra',
+                })
+              )}
+            </Label>
+            <BodyShort>
+              {formatDate(strengTilDato(forelder.flyttetFra.verdi))}
+            </BodyShort>
+          </div>
+        ) : null}
+        {forelder?.hvorMyeSammen?.verdi ? (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({
+                  id: 'barnasbosted.spm.hvorMyeSammen',
+                })
+              )}
+            </Label>
+            <BodyShort>{forelder.hvorMyeSammen.verdi}</BodyShort>
+          </div>
+        ) : null}
+        {forelder.beskrivSamværUtenBarn && (
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              {hentBeskjedMedNavn(
+                barnetsNavn,
+                intl.formatMessage({
+                  id: 'barnasbosted.spm.beskrivSamværUtenBarn',
+                })
+              )}
+            </Label>
+            <BodyShort>{forelder.beskrivSamværUtenBarn.verdi}</BodyShort>
+          </div>
+        )}
+        <LenkeMedIkon
+          onClick={endreInformasjon}
+          tekst_id="barnasbosted.knapp.endre"
+          ikon={endre}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default BarnetsBostedLagtTil;

--- a/src/barnetilsyn/steg/4-barnasbosted/ForeldreConfig.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/ForeldreConfig.tsx
@@ -1,0 +1,213 @@
+import { ESvarTekstid, ISpørsmål } from '../../../models/felles/spørsmålogsvar';
+import {
+  EBorAnnenForelderISammeHus,
+  EHarSamværMedBarn,
+  EHarSkriftligSamværsavtale,
+  EHvorforIkkeOppgi,
+  EHvorMyeSammen,
+  ESkalBarnetBoHosSøker,
+} from '../../../models/steg/barnasbosted';
+import { IDokumentasjon } from '../../../models/steg/dokumentasjon';
+import { IBarn } from '../../../models/steg/barn';
+import { EForelder } from '../../../models/steg/forelder';
+import { JaNeiSvar } from '../../../helpers/svar';
+import { DokumentasjonsConfig } from '../../DokumentasjonsConfig';
+import { LokalIntlShape } from '../../../language/typer';
+
+// --- Dokumentasjon
+
+const DokumentasjonBarnBorHosDeg: IDokumentasjon =
+  DokumentasjonsConfig.DokumentasjonBarnBorHosDeg;
+
+const SamværsavtaleMedKonkreteTidspunkter: IDokumentasjon =
+  DokumentasjonsConfig.SamværsavtaleMedKonkreteTidspunkter;
+
+const SamværsavtaleUtenKonkreteTidspunkter: IDokumentasjon =
+  DokumentasjonsConfig.SamværsavtaleUtenKonkreteTidspunkter;
+// --- Spørsmål
+
+export const borINorge = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EForelder.borINorge,
+  tekstid: 'barnasbosted.borinorge',
+  flersvar: false,
+  svaralternativer: JaNeiSvar(intl),
+});
+
+export const boddSammenFør = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: 'boddSammenFør',
+  tekstid: 'barnasbosted.spm.boddsammenfør',
+  flersvar: false,
+  svaralternativer: JaNeiSvar(intl),
+});
+
+export const hvorforIkkeOppgi = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EForelder.hvorforIkkeOppgi,
+  tekstid: 'barnasbosted.spm.hvorforikkeoppgi',
+  flersvar: false,
+  svaralternativer: [
+    {
+      id: EHvorforIkkeOppgi.donorbarn,
+      svar_tekst: intl.formatMessage({ id: 'barnasbosted.spm.donorbarn' }),
+    },
+    {
+      id: EHvorforIkkeOppgi.annet,
+      svar_tekst: intl.formatMessage({ id: 'barnasbosted.spm.annet' }),
+    },
+  ],
+});
+
+export const harAnnenForelderSamværMedBarn = (
+  intl: LokalIntlShape,
+  barn: IBarn
+): ISpørsmål => ({
+  søknadid: EForelder.harAnnenForelderSamværMedBarn,
+  tekstid: barn.født?.verdi
+    ? 'barnasbosted.spm.harAnnenForelderSamværMedBarn'
+    : 'barnasbosted.spm.harAnnenForelderSamværMedBarn.ufødt',
+  flersvar: false,
+  lesmer: {
+    headerTekstid: '',
+    innholdTekstid: 'barnasbosted.hjelpetekst.samvær.innhold',
+  },
+  svaralternativer: [
+    {
+      id: EHarSamværMedBarn.jaIkkeMerEnnVanlig,
+      svar_tekst: intl.formatMessage({
+        id: 'barnasbosted.spm.jaIkkeMerEnnVanlig',
+      }),
+    },
+    {
+      id: EHarSamværMedBarn.jaMerEnnVanlig,
+      svar_tekst: intl.formatMessage({ id: 'barnasbosted.spm.jaMerEnnVanlig' }),
+    },
+    {
+      id: EHarSamværMedBarn.nei,
+      svar_tekst: intl.formatMessage({
+        id: barn.født?.verdi
+          ? 'barnasbosted.spm.andreForelderenSamværNei'
+          : 'barnasbosted.spm.andreForelderenSamværNei.ufødt',
+      }),
+    },
+  ],
+});
+
+export const harDereSkriftligSamværsavtale = (
+  intl: LokalIntlShape
+): ISpørsmål => ({
+  søknadid: EForelder.harDereSkriftligSamværsavtale,
+  tekstid: 'barnasbosted.spm.harDereSkriftligSamværsavtale',
+  flersvar: false,
+  lesmer: {
+    innholdTekstid:
+      'barnasbosted.hjelpetekst-innhold.harDereSkriftligSamværsavtale',
+    headerTekstid:
+      'barnasbosted.hjelpetekst-åpne.harDereSkriftligSamværsavtale',
+  },
+  svaralternativer: [
+    {
+      id: EHarSkriftligSamværsavtale.jaKonkreteTidspunkter,
+      svar_tekst: intl.formatMessage({
+        id: 'barnasbosted.spm.jaKonkreteTidspunkt',
+      }),
+      dokumentasjonsbehov: SamværsavtaleMedKonkreteTidspunkter,
+    },
+    {
+      id: EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter,
+      svar_tekst: intl.formatMessage({
+        id: 'barnasbosted.spm.jaIkkeKonkreteTidspunkt',
+      }),
+      dokumentasjonsbehov: SamværsavtaleUtenKonkreteTidspunkter,
+    },
+    {
+      id: EHarSkriftligSamværsavtale.nei,
+      svar_tekst: intl.formatMessage({ id: ESvarTekstid.NEI }),
+    },
+  ],
+});
+
+export const borAnnenForelderISammeHus = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: 'borAnnenForelderISammeHus',
+  tekstid: 'barnasbosted.spm.borAnnenForelderISammeHus',
+  lesmer: {
+    headerTekstid: 'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.apne',
+    innholdTekstid:
+      'barnasbosted.hjelpetekst.borAnnenForelderISammeHus.innhold',
+  },
+  flersvar: false,
+  svaralternativer: [
+    {
+      id: EBorAnnenForelderISammeHus.ja,
+      svar_tekst: intl.formatMessage({ id: ESvarTekstid.JA }),
+    },
+    {
+      id: EBorAnnenForelderISammeHus.nei,
+      svar_tekst: intl.formatMessage({ id: ESvarTekstid.NEI }),
+    },
+    {
+      id: EBorAnnenForelderISammeHus.vetikke,
+      svar_tekst: intl.formatMessage({ id: 'barnasbosted.spm.vetikke' }),
+    },
+  ],
+});
+
+export const hvorMyeSammen = (
+  intl: LokalIntlShape,
+  barn: IBarn
+): ISpørsmål => ({
+  søknadid: 'hvorMyeSammen',
+  tekstid: 'barnasbosted.spm.hvorMyeSammen',
+  flersvar: false,
+  lesmer: {
+    headerTekstid: 'barnasbosted.lesmer-åpne.hvorMyeSammen',
+    innholdTekstid: 'barnasbosted.lesmer-innhold.hvorMyeSammen',
+  },
+  svaralternativer: [
+    {
+      id: EHvorMyeSammen.møtesIkke,
+      svar_tekst: intl.formatMessage({ id: 'barnasbosted.spm.møtesIkke' }),
+    },
+    {
+      id: EHvorMyeSammen.kunNårLeveres,
+      svar_tekst: barn.født?.verdi
+        ? intl.formatMessage({ id: 'barnasbosted.spm.kunNårLeveres' })
+        : intl.formatMessage({ id: 'barnasbosted.spm.kunNårLeveres.ufødt' }),
+    },
+    {
+      id: EHvorMyeSammen.møtesUtenom,
+      svar_tekst: barn.født?.verdi
+        ? intl.formatMessage({ id: 'barnasbosted.spm.møtesUtenom' })
+        : intl.formatMessage({ id: 'barnasbosted.spm.møtesUtenom.ufødt' }),
+    },
+  ],
+});
+
+export const skalBarnetBoHosSøker = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EForelder.skalBarnetBoHosSøker,
+  tekstid: 'barnasbosted.spm.skalBarnetBoHosSøker',
+  flersvar: false,
+  svaralternativer: [
+    {
+      id: ESkalBarnetBoHosSøker.ja,
+      svar_tekst: intl.formatMessage({
+        id: 'barnasbosted.spm.jaFolkeregistrert',
+      }),
+    },
+    {
+      id: ESkalBarnetBoHosSøker.jaMenSamarbeiderIkke,
+      svar_tekst: intl.formatMessage({
+        id: 'barnasbosted.spm.jaMenSamarbeiderIkke',
+      }),
+      dokumentasjonsbehov: DokumentasjonBarnBorHosDeg,
+    },
+    {
+      id: ESkalBarnetBoHosSøker.neiMenAvtaleDeltBosted,
+      svar_tekst: intl.formatMessage({
+        id: 'barnasbosted.spm.neiMenAvtaleDeltBosted',
+      }),
+    },
+    {
+      id: ESkalBarnetBoHosSøker.nei,
+      svar_tekst: intl.formatMessage({ id: ESvarTekstid.NEI }),
+    },
+  ],
+});

--- a/src/barnetilsyn/steg/4-barnasbosted/HvordanPraktiseresSamværet.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/HvordanPraktiseresSamværet.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { IForelder } from '../../../models/steg/forelder';
+import { BodyShort, Label, Textarea } from '@navikt/ds-react';
+
+interface Props {
+  forelder: IForelder;
+  settForelder: (verdi: IForelder) => void;
+}
+
+const HvordanPraktiseresSamværet: React.FC<Props> = ({
+  forelder,
+  settForelder,
+}) => {
+  const intl = useLokalIntlContext();
+
+  return (
+    <KomponentGruppe className="hvordan-praktiseres-samværet">
+      <FeltGruppe>
+        <Label as="p">
+          {intl.formatMessage({ id: 'barnasbosted.element.samvær' })}
+        </Label>
+        <BodyShort>
+          {intl.formatMessage({ id: 'barnasbosted.normaltekst.opplysninger' })}
+        </BodyShort>
+        <ul>
+          <li>
+            <BodyShort>
+              {intl.formatMessage({
+                id: 'barnasbosted.normaltekst.hvormangedager',
+              })}
+            </BodyShort>
+          </li>
+          <li>
+            <BodyShort>
+              {intl.formatMessage({
+                id: 'barnasbosted.normaltekst.nårreiserbarnet',
+              })}
+            </BodyShort>
+          </li>
+        </ul>
+      </FeltGruppe>
+      <FeltGruppe>
+        <Textarea
+          autoComplete={'off'}
+          value={
+            forelder.hvordanPraktiseresSamværet &&
+            forelder.hvordanPraktiseresSamværet.verdi
+              ? forelder.hvordanPraktiseresSamværet.verdi
+              : ''
+          }
+          onChange={(e) =>
+            settForelder({
+              ...forelder,
+              hvordanPraktiseresSamværet: {
+                label: intl.formatMessage({
+                  id: 'barnasbosted.element.samvær',
+                }),
+                verdi: e.target.value,
+              },
+            })
+          }
+          label=""
+        />
+      </FeltGruppe>
+    </KomponentGruppe>
+  );
+};
+
+export default HvordanPraktiseresSamværet;

--- a/src/barnetilsyn/steg/4-barnasbosted/OmAndreForelder.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/OmAndreForelder.tsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useState } from 'react';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import MultiSvarSpørsmål from '../../../components/spørsmål/MultiSvarSpørsmål';
+import { EHvorforIkkeOppgi } from '../../../models/steg/barnasbosted';
+import { hentTekst } from '../../../utils/søknad';
+import { hvorforIkkeOppgi } from './ForeldreConfig';
+import { IForelder } from '../../../models/steg/forelder';
+import { ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
+import { hentUid } from '../../../utils/autentiseringogvalidering/uuid';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import IdentEllerFødselsdatoGruppe from '../../../components/gruppe/IdentEllerFødselsdatoGruppe';
+import { Checkbox, ErrorMessage, Textarea } from '@navikt/ds-react';
+import {
+  erIkkeOppgittPgaAnnet,
+  slettIrrelevantPropertiesHvisHuketAvKanIkkeOppgiAnnenForelder,
+} from '../../../helpers/steg/forelder';
+import { TextFieldMedBredde } from '../../../components/TextFieldMedBredde';
+
+interface Props {
+  settForelder: (verdi: IForelder) => void;
+  forelder: IForelder;
+  kjennerIkkeIdent: boolean;
+  settKjennerIkkeIdent: (kjennerIkkeIdent: boolean) => void;
+  settSisteBarnUtfylt: (sisteBarnUtfylt: boolean) => void;
+}
+
+const OmAndreForelder: React.FC<Props> = ({
+  settForelder,
+  forelder,
+  kjennerIkkeIdent,
+  settKjennerIkkeIdent,
+  settSisteBarnUtfylt,
+}) => {
+  const intl = useLokalIntlContext();
+  const { fødselsdato, ident } = forelder;
+  const [feilmeldingNavn, settFeilmeldingNavn] = useState<boolean>(false);
+  const hvorforIkkeOppgiLabel = hentTekst(hvorforIkkeOppgi(intl).tekstid, intl);
+  const jegKanIkkeOppgiLabel = hentTekst(
+    'barnasbosted.kanikkeoppgiforelder',
+    intl
+  );
+  const [erGyldigIdent, settGyldigIdent] = useState<boolean>(
+    !!forelder?.ident?.verdi
+  );
+  const [identFelt, settIdentFelt] = useState<string>(
+    ident?.verdi ? ident.verdi : ''
+  );
+
+  useEffect(() => {
+    erGyldigIdent &&
+      settForelder({
+        ...forelder,
+        ident: { label: hentTekst('person.ident', intl), verdi: identFelt },
+      });
+
+    if (!erGyldigIdent) {
+      const nyForelder = { ...forelder };
+
+      delete nyForelder.ident;
+
+      settForelder(nyForelder);
+    }
+
+    // eslint-disable-next-line
+  }, [erGyldigIdent, identFelt]);
+
+  const hvisGyldigIdentSettIdent = (erGyldig: boolean) => {
+    settGyldigIdent(erGyldig);
+  };
+
+  const oppdaterIdent = (e: React.FormEvent<HTMLInputElement>) => {
+    settIdentFelt(e.currentTarget.value);
+  };
+
+  const settChecked = (checked: boolean) => {
+    const endretForelder = forelder;
+    if (checked) {
+      delete endretForelder.ident;
+      settIdentFelt('');
+    }
+    if (!checked && fødselsdato) {
+      delete endretForelder.fødselsdato;
+    }
+
+    settForelder(endretForelder);
+    settKjennerIkkeIdent(checked);
+  };
+
+  const settFødselsdato = (dato: string) => {
+    dato !== null &&
+      settForelder({
+        ...forelder,
+        fødselsdato: {
+          label: hentTekst('datovelger.fødselsdato', intl),
+          verdi: dato,
+        },
+      });
+  };
+
+  const hukAvKanIkkeOppgiAnnenForelder = (avhuket: boolean) => {
+    const nyForelder = { ...forelder };
+
+    if (avhuket) {
+      slettIrrelevantPropertiesHvisHuketAvKanIkkeOppgiAnnenForelder(nyForelder);
+      settFeilmeldingNavn(false);
+    } else {
+      delete nyForelder.ikkeOppgittAnnenForelderBegrunnelse;
+      delete nyForelder.hvorforIkkeOppgi;
+      delete nyForelder.kanIkkeOppgiAnnenForelderFar;
+      nyForelder.id = hentUid();
+      settFeilmeldingNavn(true);
+    }
+
+    settForelder({
+      ...nyForelder,
+      kanIkkeOppgiAnnenForelderFar: {
+        label: jegKanIkkeOppgiLabel,
+        verdi: !forelder.kanIkkeOppgiAnnenForelderFar?.verdi,
+      },
+    });
+  };
+
+  const settHvorforIkkeOppgi = (spørsmål: ISpørsmål, svar: ISvar) => {
+    const verdi = svar.id === EHvorforIkkeOppgi.donorbarn ? 'Donor' : '';
+
+    const nyForelder = {
+      ...forelder,
+      [spørsmål.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: svar.id,
+        label: hentTekst(spørsmål.tekstid, intl),
+        verdi: svar.svar_tekst,
+      },
+      ikkeOppgittAnnenForelderBegrunnelse: {
+        label: hentTekst('barnasbosted.spm.hvorforikkeoppgi', intl),
+        verdi: verdi,
+      },
+    };
+
+    settForelder(nyForelder);
+  };
+
+  const settIkkeOppgittAnnenForelderBegrunnelse = (begrunnelse: string) => {
+    settForelder({
+      ...forelder,
+      ikkeOppgittAnnenForelderBegrunnelse: {
+        label: hentTekst('barnasbosted.spm.hvorforikkeoppgi', intl),
+        verdi: begrunnelse,
+      },
+    });
+  };
+
+  return (
+    <>
+      <KomponentGruppe>
+        <FeltGruppe>
+          <TextFieldMedBredde
+            bredde={'L'}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              settForelder({
+                ...forelder,
+                navn: {
+                  label: hentTekst('person.navn', intl),
+                  verdi: e.target.value,
+                },
+              });
+              e.target.value === '' && settSisteBarnUtfylt(false);
+            }}
+            onBlur={(e: React.ChangeEvent<HTMLInputElement>) =>
+              e.target.value === ''
+                ? settFeilmeldingNavn(true)
+                : settFeilmeldingNavn(false)
+            }
+            value={forelder.navn ? forelder.navn?.verdi : ''}
+            label={hentTekst('person.navn', intl)}
+            disabled={forelder.kanIkkeOppgiAnnenForelderFar?.verdi}
+          />
+          {feilmeldingNavn && (
+            <ErrorMessage className={'skjemaelement__feilmelding'}>
+              {intl.formatMessage({ id: 'person.feilmelding.navn' })}
+            </ErrorMessage>
+          )}
+        </FeltGruppe>
+        <FeltGruppe>
+          <Checkbox
+            checked={
+              forelder.kanIkkeOppgiAnnenForelderFar?.verdi
+                ? forelder.kanIkkeOppgiAnnenForelderFar?.verdi
+                : false
+            }
+            onChange={(e) => hukAvKanIkkeOppgiAnnenForelder(e.target.checked)}
+          >
+            {hentTekst('barnasbosted.kanikkeoppgiforelder', intl)}
+          </Checkbox>
+        </FeltGruppe>
+      </KomponentGruppe>
+      {forelder.navn && !forelder.kanIkkeOppgiAnnenForelderFar?.verdi && (
+        <IdentEllerFødselsdatoGruppe
+          identLabel={hentTekst('person.ident', intl)}
+          datoLabel={hentTekst('person.fødselsdato', intl)}
+          checkboxLabel={hentTekst('person.checkbox.ident', intl)}
+          ident={identFelt && !kjennerIkkeIdent ? identFelt : ''}
+          fødselsdato={forelder?.fødselsdato?.verdi || ''}
+          checked={kjennerIkkeIdent}
+          erGyldigIdent={erGyldigIdent}
+          settGyldigIdent={hvisGyldigIdentSettIdent}
+          settFødselsdato={settFødselsdato}
+          settChecked={settChecked}
+          settIdent={oppdaterIdent}
+        />
+      )}
+      {forelder.kanIkkeOppgiAnnenForelderFar?.verdi && (
+        <KomponentGruppe>
+          <MultiSvarSpørsmål
+            spørsmål={hvorforIkkeOppgi(intl)}
+            settSpørsmålOgSvar={settHvorforIkkeOppgi}
+            valgtSvar={
+              forelder.hvorforIkkeOppgi?.svarid === EHvorforIkkeOppgi.annet
+                ? hentTekst('barnasbosted.spm.annet', intl)
+                : forelder.hvorforIkkeOppgi?.verdi
+            }
+          />
+        </KomponentGruppe>
+      )}
+      {erIkkeOppgittPgaAnnet(forelder) && (
+        <FeltGruppe aria-live="polite">
+          <Textarea
+            autoComplete={'off'}
+            value={forelder.ikkeOppgittAnnenForelderBegrunnelse?.verdi}
+            onChange={(e) =>
+              settIkkeOppgittAnnenForelderBegrunnelse(e.target.value)
+            }
+            label={hvorforIkkeOppgiLabel}
+          />
+        </FeltGruppe>
+      )}
+    </>
+  );
+};
+
+export default OmAndreForelder;

--- a/src/barnetilsyn/steg/4-barnasbosted/SkalBarnetBoHosSøker.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/SkalBarnetBoHosSøker.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { hentTekst } from '../../../utils/søknad';
+import { ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
+import { skalBarnetBoHosSøker } from './ForeldreConfig';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { IForelder } from '../../../models/steg/forelder';
+import { IBarn } from '../../../models/steg/barn';
+import MultiSvarSpørsmålMedNavn from '../../../components/spørsmål/MultiSvarSpørsmålMedNavn';
+import {
+  hentBarnNavnEllerBarnet,
+  hentSpørsmålTekstMedNavnEllerBarn,
+} from '../../../utils/barn';
+import { ESkalBarnetBoHosSøker } from '../../../models/steg/barnasbosted';
+import AlertStripeDokumentasjon from '../../../components/AlertstripeDokumentasjon';
+import FormattedHtmlMessage from '../../../language/FormattedHtmlMessage';
+import { Alert } from '@navikt/ds-react';
+import { SettDokumentasjonsbehovBarn } from '../../../models/søknad/søknad';
+
+interface Props {
+  barn: IBarn;
+  forelder: IForelder;
+  settForelder: (forelder: IForelder) => void;
+  settDokumentasjonsbehovForBarn: SettDokumentasjonsbehovBarn;
+}
+
+const SkalBarnetBoHosSøker: React.FC<Props> = ({
+  barn,
+  forelder,
+  settForelder,
+  settDokumentasjonsbehovForBarn,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const skalBarnetBoHosSøkerConfig = skalBarnetBoHosSøker(intl);
+  const settSkalBarnetBoHosSøkerFelt = (spørsmål: ISpørsmål, svar: ISvar) => {
+    settForelder({
+      ...forelder,
+      [skalBarnetBoHosSøkerConfig.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: svar.id,
+        label: hentTekst('barnasbosted.spm.skalBarnetBoHosSøker', intl),
+        verdi: svar.svar_tekst,
+      },
+    });
+    settDokumentasjonsbehovForBarn(spørsmål, svar, barn.id);
+  };
+
+  const hentSpørsmålTekst = (tekstid: string) => {
+    const navnEllerBarn = barn.født?.verdi
+      ? barn.navn.verdi
+      : hentTekst('barnet.storForBokstav', intl);
+    return hentSpørsmålTekstMedNavnEllerBarn(tekstid, navnEllerBarn, intl);
+  };
+
+  return (
+    <>
+      <FeltGruppe>
+        <Alert size="small" variant="warning" inline>
+          {hentSpørsmålTekst('barnasbosted.alert.måBoHosDeg')}
+        </Alert>
+      </FeltGruppe>
+      <KomponentGruppe>
+        <MultiSvarSpørsmålMedNavn
+          key={skalBarnetBoHosSøkerConfig.søknadid}
+          spørsmål={skalBarnetBoHosSøkerConfig}
+          spørsmålTekst={hentBarnNavnEllerBarnet(
+            barn,
+            skalBarnetBoHosSøkerConfig.tekstid,
+            intl
+          )}
+          valgtSvar={forelder.skalBarnetBoHosSøker?.verdi}
+          settSpørsmålOgSvar={settSkalBarnetBoHosSøkerFelt}
+        />
+      </KomponentGruppe>
+      {forelder.skalBarnetBoHosSøker?.svarid ===
+        ESkalBarnetBoHosSøker.jaMenSamarbeiderIkke && (
+        <FeltGruppe>
+          <AlertStripeDokumentasjon>
+            <FormattedHtmlMessage
+              id={hentBarnNavnEllerBarnet(
+                barn,
+                'barnasbosted.alert.hvisFaktiskBor',
+                intl
+              )}
+            />
+          </AlertStripeDokumentasjon>
+        </FeltGruppe>
+      )}
+      {forelder.skalBarnetBoHosSøker?.svarid === ESkalBarnetBoHosSøker.ja && (
+        <FeltGruppe>
+          <Alert size="small" variant="info" inline>
+            {hentTekst('barnasbosted.alert.skalBarnetBoHosSøker.ja', intl)}
+          </Alert>
+        </FeltGruppe>
+      )}
+      {forelder.skalBarnetBoHosSøker?.svarid === ESkalBarnetBoHosSøker.nei && (
+        <FeltGruppe>
+          <Alert size="small" variant="warning" inline>
+            {hentTekst('barnasbosted.alert.skalBarnetBoHosSøker.nei', intl)}
+          </Alert>
+        </FeltGruppe>
+      )}
+    </>
+  );
+};
+
+export default SkalBarnetBoHosSøker;

--- a/src/barnetilsyn/steg/4-barnasbosted/bostedOgSamvær/BorForelderINorge.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/bostedOgSamvær/BorForelderINorge.tsx
@@ -1,0 +1,116 @@
+import React, { FC } from 'react';
+import { EForelder, IForelder } from '../../../../models/steg/forelder';
+import {
+  ESvar,
+  ISpørsmål,
+  ISvar,
+} from '../../../../models/felles/spørsmålogsvar';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import { borINorge } from '../ForeldreConfig';
+import { hentTekst } from '../../../../utils/søknad';
+import JaNeiSpørsmålMedNavn from '../../../../components/spørsmål/JaNeiSpørsmålMedNavn';
+import { IBarn } from '../../../../models/steg/barn';
+import { hentBarnNavnEllerBarnet } from '../../../../utils/barn';
+import {
+  erJaNeiSvar,
+  hentBooleanFraValgtSvar,
+} from '../../../../utils/spørsmålogsvar';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import SelectSpørsmål from '../../../../components/spørsmål/SelectSpørsmål';
+import { useSpråkContext } from '../../../../context/SpråkContext';
+import { hentLand } from '../../1-omdeg/medlemskap/MedlemskapConfig';
+import { ILandMedKode } from '../../../../models/steg/omDeg/medlemskap';
+import { SettDokumentasjonsbehovBarn } from '../../../../models/søknad/søknad';
+
+const utledOppholdslandConfig = (land: ILandMedKode[]): ISpørsmål => ({
+  søknadid: 'denAndreForelderensOppholdsland',
+  tekstid: 'barnasbosted.hvilketLand',
+  flersvar: false,
+  svaralternativer: land,
+});
+
+interface Props {
+  barn: IBarn;
+  forelder: IForelder;
+  settForelder: (verdi: IForelder) => void;
+  settDokumentasjonsbehovForBarn: SettDokumentasjonsbehovBarn;
+}
+
+const BorForelderINorge: FC<Props> = ({
+  settForelder,
+  barn,
+  forelder,
+  settDokumentasjonsbehovForBarn,
+}) => {
+  const [locale] = useSpråkContext();
+  const land = hentLand(locale);
+  const oppholdslandConfig = utledOppholdslandConfig(land);
+  const intl = useLokalIntlContext();
+
+  const settFelt = (spørsmål: ISpørsmål, svar: ISvar) => {
+    const nyForelder = {
+      ...forelder,
+      [spørsmål.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: svar.id,
+        label: hentTekst(spørsmål.tekstid, intl),
+        verdi: erJaNeiSvar(svar)
+          ? hentBooleanFraValgtSvar(svar)
+          : svar.svar_tekst,
+      },
+    };
+
+    if (
+      spørsmål.søknadid === EForelder.borINorge &&
+      nyForelder.land &&
+      svar.id === ESvar.JA
+    ) {
+      delete nyForelder.land;
+    }
+    settForelder(nyForelder);
+    settDokumentasjonsbehovForBarn(spørsmål, svar, barn.id);
+  };
+
+  const oppdaterMedforeldersOppholdsland = (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar
+  ) => {
+    settForelder({
+      ...forelder,
+      land: {
+        label: hentTekst('barnasbosted.land', intl),
+        verdi: valgtSvar.svar_tekst,
+        svarid: valgtSvar.id,
+        spørsmålid: spørsmål.søknadid,
+      },
+    });
+  };
+
+  return (
+    <>
+      <KomponentGruppe>
+        <JaNeiSpørsmålMedNavn
+          spørsmål={borINorge(intl)}
+          spørsmålTekst={hentBarnNavnEllerBarnet(
+            barn,
+            borINorge(intl).tekstid,
+            intl
+          )}
+          onChange={settFelt}
+          valgtSvar={forelder.borINorge?.verdi}
+        />
+      </KomponentGruppe>
+      {forelder.borINorge?.verdi === false && (
+        <KomponentGruppe>
+          <SelectSpørsmål
+            spørsmål={oppholdslandConfig}
+            valgtSvarId={forelder.land?.svarid}
+            settSpørsmålOgSvar={oppdaterMedforeldersOppholdsland}
+          />
+        </KomponentGruppe>
+      )}
+    </>
+  );
+};
+
+export default BorForelderINorge;

--- a/src/barnetilsyn/steg/4-barnasbosted/bostedOgSamvær/BostedOgSamvær.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/bostedOgSamvær/BostedOgSamvær.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import { harAnnenForelderSamværMedBarn } from '../ForeldreConfig';
+import HvordanPraktiseresSamværet from '../HvordanPraktiseresSamværet';
+import {
+  ESvar,
+  ISpørsmål,
+  ISvar,
+} from '../../../../models/felles/spørsmålogsvar';
+import { hentTekst } from '../../../../utils/søknad';
+import { EForelder, IForelder } from '../../../../models/steg/forelder';
+import {
+  erJaNeiSvar,
+  hentBooleanFraValgtSvar,
+} from '../../../../utils/spørsmålogsvar';
+import HarForelderSkriftligSamværsavtale from './HarForelderSkriftligSamværsavtale';
+import {
+  harForelderSamværMedBarn,
+  hvisEndretSvarSlettFeltHvordanPraktiseresSamværet,
+  måBeskriveSamværet,
+} from '../../../../helpers/steg/forelder';
+import { IBarn } from '../../../../models/steg/barn';
+import MultiSvarSpørsmålMedNavn from '../../../../components/spørsmål/MultiSvarSpørsmålMedNavn';
+import { hentBarnNavnEllerBarnet } from '../../../../utils/barn';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { SettDokumentasjonsbehovBarn } from '../../../../models/søknad/søknad';
+
+interface Props {
+  settForelder: (verdi: IForelder) => void;
+  forelder: IForelder;
+  barn: IBarn;
+  settDokumentasjonsbehovForBarn: SettDokumentasjonsbehovBarn;
+}
+
+const BostedOgSamvær: React.FC<Props> = ({
+  settForelder,
+  forelder,
+  barn,
+  settDokumentasjonsbehovForBarn,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const harAnnenForelderSamværMedBarnConfig = harAnnenForelderSamværMedBarn(
+    intl,
+    barn
+  );
+
+  const settBostedOgSamværFelt = (spørsmål: ISpørsmål, svar: ISvar) => {
+    const nyForelder = {
+      ...forelder,
+      [spørsmål.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: svar.id,
+        label: hentTekst(spørsmål.tekstid, intl),
+        verdi: erJaNeiSvar(svar)
+          ? hentBooleanFraValgtSvar(svar)
+          : svar.svar_tekst,
+      },
+    };
+
+    if (
+      hvisEndretSvarSlettFeltHvordanPraktiseresSamværet(spørsmål, svar) &&
+      nyForelder.hvordanPraktiseresSamværet
+    )
+      delete nyForelder.hvordanPraktiseresSamværet;
+
+    if (
+      spørsmål.søknadid === EForelder.borINorge &&
+      nyForelder.land &&
+      svar.id === ESvar.JA
+    ) {
+      delete nyForelder.land;
+    }
+
+    settForelder(nyForelder);
+    settDokumentasjonsbehovForBarn(spørsmål, svar, barn.id);
+  };
+
+  return (
+    <>
+      <KomponentGruppe>
+        <MultiSvarSpørsmålMedNavn
+          key={harAnnenForelderSamværMedBarnConfig.søknadid}
+          spørsmål={harAnnenForelderSamværMedBarnConfig}
+          spørsmålTekst={hentBarnNavnEllerBarnet(
+            barn,
+            harAnnenForelderSamværMedBarnConfig.tekstid,
+            intl
+          )}
+          valgtSvar={forelder.harAnnenForelderSamværMedBarn?.verdi}
+          settSpørsmålOgSvar={settBostedOgSamværFelt}
+        />
+      </KomponentGruppe>
+      {harForelderSamværMedBarn(
+        forelder.harAnnenForelderSamværMedBarn?.svarid
+      ) && (
+        <HarForelderSkriftligSamværsavtale
+          forelder={forelder}
+          settBostedOgSamværFelt={settBostedOgSamværFelt}
+          barn={barn}
+        />
+      )}
+      {måBeskriveSamværet(
+        forelder.harDereSkriftligSamværsavtale?.svarid,
+        forelder.harAnnenForelderSamværMedBarn?.svarid
+      ) && (
+        <HvordanPraktiseresSamværet
+          forelder={forelder}
+          settForelder={settForelder}
+        />
+      )}
+    </>
+  );
+};
+
+export default BostedOgSamvær;

--- a/src/barnetilsyn/steg/4-barnasbosted/bostedOgSamvær/HarForelderSkriftligSamværsavtale.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/bostedOgSamvær/HarForelderSkriftligSamværsavtale.tsx
@@ -1,0 +1,58 @@
+import React, { FC } from 'react';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import { harDereSkriftligSamværsavtale } from '../ForeldreConfig';
+import { EHarSkriftligSamværsavtale } from '../../../../models/steg/barnasbosted';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import { IForelder } from '../../../../models/steg/forelder';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import { IBarn } from '../../../../models/steg/barn';
+import MultiSvarSpørsmålMedNavn from '../../../../components/spørsmål/MultiSvarSpørsmålMedNavn';
+import { hentBarnNavnEllerBarnet } from '../../../../utils/barn';
+import AlertStripeDokumentasjon from '../../../../components/AlertstripeDokumentasjon';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+
+interface Props {
+  forelder: IForelder;
+  settBostedOgSamværFelt: (spørsmål: ISpørsmål, svar: ISvar) => void;
+  barn: IBarn;
+}
+const HarForelderSkriftligSamværsavtale: FC<Props> = ({
+  forelder,
+  settBostedOgSamværFelt,
+  barn,
+}) => {
+  const intl = useLokalIntlContext();
+  const harDereSkriftligSamværsavtaleSpm = harDereSkriftligSamværsavtale(intl);
+  return (
+    <>
+      <KomponentGruppe>
+        <MultiSvarSpørsmålMedNavn
+          key={harDereSkriftligSamværsavtaleSpm.søknadid}
+          spørsmål={harDereSkriftligSamværsavtaleSpm}
+          spørsmålTekst={hentBarnNavnEllerBarnet(
+            barn,
+            harDereSkriftligSamværsavtaleSpm.tekstid,
+            intl
+          )}
+          valgtSvar={forelder.harDereSkriftligSamværsavtale?.verdi}
+          settSpørsmålOgSvar={settBostedOgSamværFelt}
+        />
+        {(forelder.harDereSkriftligSamværsavtale?.svarid ===
+          EHarSkriftligSamværsavtale.jaIkkeKonkreteTidspunkter ||
+          forelder.harDereSkriftligSamværsavtale?.svarid ===
+            EHarSkriftligSamværsavtale.jaKonkreteTidspunkter) && (
+          <FeltGruppe>
+            <AlertStripeDokumentasjon>
+              <LocaleTekst
+                tekst={'barnasbosted.alert.leggeVedSamværsavtalen'}
+              />
+            </AlertStripeDokumentasjon>
+          </FeltGruppe>
+        )}
+      </KomponentGruppe>
+    </>
+  );
+};
+
+export default HarForelderSkriftligSamværsavtale;

--- a/src/barnetilsyn/steg/4-barnasbosted/ikkesammeforelder/BoddSammenFør.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/ikkesammeforelder/BoddSammenFør.tsx
@@ -1,0 +1,89 @@
+import { IForelder } from '../../../../models/steg/forelder';
+import React, { FC } from 'react';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import { boddSammenFør } from '../ForeldreConfig';
+import {
+  ESvar,
+  ISpørsmål,
+  ISvar,
+} from '../../../../models/felles/spørsmålogsvar';
+import { hentTekst } from '../../../../utils/søknad';
+import { hentBooleanFraValgtSvar } from '../../../../utils/spørsmålogsvar';
+import JaNeiSpørsmålMedNavn from '../../../../components/spørsmål/JaNeiSpørsmålMedNavn';
+import { hentBarnNavnEllerBarnet } from '../../../../utils/barn';
+import { IBarn } from '../../../../models/steg/barn';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import {
+  DatoBegrensning,
+  Datovelger,
+} from '../../../../components/dato/Datovelger';
+
+interface Props {
+  forelder: IForelder;
+  settForelder: (verdi: IForelder) => void;
+  barn: IBarn;
+}
+const BoddSammenFør: FC<Props> = ({ forelder, barn, settForelder }) => {
+  const intl = useLokalIntlContext();
+  const boddSammenFørSpm = boddSammenFør(intl);
+
+  const settHarBoddsammenFør = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
+    const nyForelder = {
+      ...forelder,
+      [boddSammenFørSpm.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: valgtSvar.id,
+        label: hentTekst(spørsmål.tekstid, intl),
+        verdi: hentBooleanFraValgtSvar(valgtSvar),
+      },
+    };
+
+    if (valgtSvar.id === ESvar.NEI) {
+      delete nyForelder.flyttetFra;
+    }
+
+    settForelder(nyForelder);
+  };
+
+  return (
+    <>
+      <KomponentGruppe>
+        <JaNeiSpørsmålMedNavn
+          spørsmål={boddSammenFørSpm}
+          spørsmålTekst={hentBarnNavnEllerBarnet(
+            barn,
+            boddSammenFørSpm.tekstid,
+            intl
+          )}
+          onChange={(spørsmål, svar) => settHarBoddsammenFør(spørsmål, svar)}
+          valgtSvar={forelder.boddSammenFør?.verdi}
+        />
+      </KomponentGruppe>
+      {forelder.boddSammenFør?.verdi && (
+        <KomponentGruppe>
+          <Datovelger
+            settDato={(dato: string) => {
+              settForelder({
+                ...forelder,
+                flyttetFra: {
+                  label: intl.formatMessage({
+                    id: 'barnasbosted.normaltekst.nårflyttetfra',
+                  }),
+                  verdi: dato,
+                },
+              });
+            }}
+            valgtDato={
+              forelder.flyttetFra && forelder.flyttetFra.verdi
+                ? forelder.flyttetFra.verdi
+                : undefined
+            }
+            tekstid={'barnasbosted.normaltekst.nårflyttetfra'}
+            datobegrensning={DatoBegrensning.AlleDatoer}
+          />
+        </KomponentGruppe>
+      )}
+    </>
+  );
+};
+export default BoddSammenFør;

--- a/src/barnetilsyn/steg/4-barnasbosted/ikkesammeforelder/BorAnnenForelderISammeHus.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/ikkesammeforelder/BorAnnenForelderISammeHus.tsx
@@ -1,0 +1,109 @@
+import React, { FC } from 'react';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import { borAnnenForelderISammeHus } from '../ForeldreConfig';
+import { EBorAnnenForelderISammeHus } from '../../../../models/steg/barnasbosted';
+import { hentTekst } from '../../../../utils/søknad';
+import { IForelder } from '../../../../models/steg/forelder';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import { IBarn } from '../../../../models/steg/barn';
+import MultiSvarSpørsmålMedNavn from '../../../../components/spørsmål/MultiSvarSpørsmålMedNavn';
+import { hentBarnNavnEllerBarnet } from '../../../../utils/barn';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { Textarea } from '@navikt/ds-react';
+
+interface Props {
+  forelder: IForelder;
+  settForelder: (verdi: IForelder) => void;
+  barn: IBarn;
+}
+const BorAnnenForelderISammeHus: FC<Props> = ({
+  forelder,
+  settForelder,
+  barn,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const borAnnenForelderISammeHusConfig = borAnnenForelderISammeHus(intl);
+
+  const settBorAnnenForelderISammeHus = (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar
+  ) => {
+    const nyForelder = {
+      ...forelder,
+      [borAnnenForelderISammeHusConfig.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: valgtSvar.id,
+        label: hentTekst('barnasbosted.spm.borAnnenForelderISammeHus', intl),
+        verdi: valgtSvar.svar_tekst,
+      },
+    };
+
+    if (
+      valgtSvar.id === EBorAnnenForelderISammeHus.nei ||
+      valgtSvar.id === EBorAnnenForelderISammeHus.vetikke
+    ) {
+      delete nyForelder.borAnnenForelderISammeHusBeskrivelse;
+    }
+
+    settForelder(nyForelder);
+  };
+
+  const settBorAnnenForelderISammeHusBeskrivelse = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    settForelder({
+      ...forelder,
+      borAnnenForelderISammeHusBeskrivelse: {
+        label: hentTekst(
+          'barnasbosted.spm.borAnnenForelderISammeHusBeskrivelse',
+          intl
+        ),
+        verdi: e.target.value,
+      },
+    });
+  };
+
+  return (
+    <>
+      <KomponentGruppe>
+        <MultiSvarSpørsmålMedNavn
+          key={borAnnenForelderISammeHusConfig.søknadid}
+          spørsmål={borAnnenForelderISammeHusConfig}
+          spørsmålTekst={hentBarnNavnEllerBarnet(
+            barn,
+            borAnnenForelderISammeHusConfig.tekstid,
+            intl
+          )}
+          valgtSvar={forelder.borAnnenForelderISammeHus?.verdi}
+          settSpørsmålOgSvar={(spørsmål, svar) =>
+            settBorAnnenForelderISammeHus(spørsmål, svar)
+          }
+        />
+      </KomponentGruppe>
+      {forelder.borAnnenForelderISammeHus?.svarid ===
+        EBorAnnenForelderISammeHus.ja && (
+        <>
+          <FeltGruppe>
+            <Textarea
+              autoComplete={'off'}
+              value={
+                forelder.borAnnenForelderISammeHusBeskrivelse &&
+                forelder.borAnnenForelderISammeHusBeskrivelse.verdi
+                  ? forelder.borAnnenForelderISammeHusBeskrivelse.verdi
+                  : ''
+              }
+              onChange={settBorAnnenForelderISammeHusBeskrivelse}
+              label={intl.formatMessage({
+                id: 'barnasbosted.spm.borAnnenForelderISammeHusBeskrivelse',
+              })}
+            />
+          </FeltGruppe>
+        </>
+      )}
+    </>
+  );
+};
+
+export default BorAnnenForelderISammeHus;

--- a/src/barnetilsyn/steg/4-barnasbosted/ikkesammeforelder/HvorMyeSammen.tsx
+++ b/src/barnetilsyn/steg/4-barnasbosted/ikkesammeforelder/HvorMyeSammen.tsx
@@ -1,0 +1,96 @@
+import { IForelder } from '../../../../models/steg/forelder';
+import React, { FC } from 'react';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import { hvorMyeSammen } from '../ForeldreConfig';
+import { hentTekst } from '../../../../utils/søknad';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import { EHvorMyeSammen } from '../../../../models/steg/barnasbosted';
+import { IBarn } from '../../../../models/steg/barn';
+import MultiSvarSpørsmålMedNavn from '../../../../components/spørsmål/MultiSvarSpørsmålMedNavn';
+import { hentBarnNavnEllerBarnet } from '../../../../utils/barn';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { Textarea } from '@navikt/ds-react';
+
+interface Props {
+  forelder: IForelder;
+  barn: IBarn;
+  settForelder: (verdi: IForelder) => void;
+}
+const HvorMyeSammen: FC<Props> = ({ forelder, barn, settForelder }) => {
+  const intl = useLokalIntlContext();
+
+  const hvorMyeSammenConfig = hvorMyeSammen(intl, barn);
+  const settHvorMyeSammen = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
+    const nyForelder = {
+      ...forelder,
+      [hvorMyeSammenConfig.søknadid]: {
+        spørsmålid: spørsmål.søknadid,
+        svarid: valgtSvar.id,
+        label: hentTekst('barnasbosted.spm.hvorMyeSammen', intl),
+        verdi: valgtSvar.svar_tekst,
+      },
+    };
+
+    if (
+      (valgtSvar.id === EHvorMyeSammen.kunNårLeveres ||
+        valgtSvar.id === EHvorMyeSammen.møtesIkke) &&
+      nyForelder.beskrivSamværUtenBarn?.verdi
+    ) {
+      delete nyForelder.beskrivSamværUtenBarn;
+    }
+
+    settForelder(nyForelder);
+  };
+
+  const settBeskrivSamværUtenBarn = (beskrivelse: string) => {
+    settForelder({
+      ...forelder,
+      beskrivSamværUtenBarn: {
+        label: hentTekst('barnasbosted.spm.beskrivSamværUtenBarn', intl),
+        verdi: beskrivelse,
+      },
+    });
+  };
+  return (
+    <>
+      <KomponentGruppe>
+        <MultiSvarSpørsmålMedNavn
+          key={hvorMyeSammenConfig.søknadid}
+          spørsmål={hvorMyeSammenConfig}
+          spørsmålTekst={hentBarnNavnEllerBarnet(
+            barn,
+            hvorMyeSammenConfig.tekstid,
+            intl
+          )}
+          valgtSvar={forelder.hvorMyeSammen?.verdi}
+          settSpørsmålOgSvar={(spørsmål, svar) =>
+            settHvorMyeSammen(spørsmål, svar)
+          }
+        />
+      </KomponentGruppe>
+      {forelder.hvorMyeSammen?.svarid === EHvorMyeSammen.møtesUtenom && (
+        <>
+          <FeltGruppe>
+            <Textarea
+              autoComplete={'off'}
+              value={
+                forelder.beskrivSamværUtenBarn &&
+                forelder.beskrivSamværUtenBarn.verdi
+                  ? forelder.beskrivSamværUtenBarn.verdi
+                  : ''
+              }
+              onChange={(e) => settBeskrivSamværUtenBarn(e.target.value)}
+              label={hentBarnNavnEllerBarnet(
+                barn,
+                'barnasbosted.spm.beskrivSamværUtenBarn',
+                intl
+              )}
+            />
+          </FeltGruppe>
+        </>
+      )}
+    </>
+  );
+};
+export default HvorMyeSammen;

--- a/src/barnetilsyn/steg/5-aktivitet/AktivitetConfig.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/AktivitetConfig.tsx
@@ -5,8 +5,8 @@ import {
   ErIArbeid,
 } from '../../../models/steg/aktivitet/aktivitet';
 import { IDokumentasjon } from '../../../models/steg/dokumentasjon';
-import { DokumentasjonsConfig } from '../../../søknad/DokumentasjonsConfig';
 import { LokalIntlShape } from '../../../language/typer';
+import { DokumentasjonsConfig } from '../../DokumentasjonsConfig';
 
 // --- DOKUMENTASJON
 

--- a/src/barnetilsyn/steg/5-aktivitet/AktivitetOppfølgingSpørsmål.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/AktivitetOppfølgingSpørsmål.tsx
@@ -4,10 +4,10 @@ import {
   IAktivitet,
 } from '../../../models/steg/aktivitet/aktivitet';
 import { ISpørsmål, ISvar } from '../../../models/felles/spørsmålogsvar';
-import OmArbeidsforholdetDitt from '../../../søknad/steg/5-aktivitet/arbeidsforhold/OmArbeidsforholdetDitt';
-import EgetAS from '../../../søknad/steg/5-aktivitet/aksjeselskap/EgetAS';
-import EtablererEgenVirksomhet from '../../../søknad/steg/5-aktivitet/EtablererEgenVirksomhet';
-import OmFirmaeneDine from '../../../søknad/steg/5-aktivitet/Firma/OmFirmaeneDine';
+import EtablererEgenVirksomhet from './EtablererEgenVirksomhet';
+import EgetAS from './aksjeselskap/EgetAS';
+import OmArbeidsforholdetDitt from './arbeidsforhold/OmArbeidsforholdetDitt';
+import OmFirmaeneDine from './firma/OmFirmaeneDine';
 
 interface Props {
   arbeidssituasjon: IAktivitet;

--- a/src/barnetilsyn/steg/5-aktivitet/EtablererEgenVirksomhet.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/EtablererEgenVirksomhet.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import LocaleTekst from '../../../language/LocaleTekst';
+import {
+  EAktivitet,
+  EArbeidssituasjon,
+  IAktivitet,
+} from '../../../models/steg/aktivitet/aktivitet';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { hentTekst } from '../../../utils/søknad';
+import AlertStripeDokumentasjon from '../../../components/AlertstripeDokumentasjon';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { Heading, Textarea } from '@navikt/ds-react';
+
+interface Props {
+  arbeidssituasjon: IAktivitet;
+  settArbeidssituasjon: (nyArbeidssituasjon: IAktivitet) => void;
+}
+
+const EtablererEgenVirksomhet: React.FC<Props> = ({
+  arbeidssituasjon,
+  settArbeidssituasjon,
+}) => {
+  const { etablererEgenVirksomhet } = arbeidssituasjon;
+  const intl = useLokalIntlContext();
+
+  const settTekstfelt = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
+    settArbeidssituasjon({
+      ...arbeidssituasjon,
+      etablererEgenVirksomhet: {
+        spørsmålid: EArbeidssituasjon.etablererEgenVirksomhet,
+        svarid: EAktivitet.etablererEgenVirksomhet,
+        label: hentTekst(
+          'arbeidssituasjon.label.etablererEgenVirksomhet',
+          intl
+        ),
+        verdi: e.target.value,
+      },
+    });
+  };
+
+  return (
+    <>
+      <FeltGruppe>
+        <Heading size="small" level="3">
+          <LocaleTekst
+            tekst={'arbeidssituasjon.tittel.etablererEgenVirksomhet'}
+          />
+        </Heading>
+      </FeltGruppe>
+      <KomponentGruppe>
+        <Textarea
+          autoComplete={'off'}
+          label={intl.formatMessage({
+            id: 'arbeidssituasjon.label.etablererEgenVirksomhet',
+          })}
+          value={
+            etablererEgenVirksomhet?.verdi ? etablererEgenVirksomhet.verdi : ''
+          }
+          maxLength={2000}
+          onChange={(e) => settTekstfelt(e)}
+        />
+        <FeltGruppe>
+          <AlertStripeDokumentasjon>
+            <LocaleTekst
+              tekst={'arbeidssituasjon.alert.etablererEgenVirksomhet'}
+            />
+          </AlertStripeDokumentasjon>
+        </FeltGruppe>
+      </KomponentGruppe>
+    </>
+  );
+};
+
+export default EtablererEgenVirksomhet;

--- a/src/barnetilsyn/steg/5-aktivitet/aksjeselskap/Aksjeselskap.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/aksjeselskap/Aksjeselskap.tsx
@@ -1,0 +1,130 @@
+import React, { FC, useEffect, useState } from 'react';
+import { TittelOgSlettKnapp } from '../../../../components/knapper/TittelOgSlettKnapp';
+import { SlettKnapp } from '../../../../components/knapper/SlettKnapp';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import InputLabelGruppe from '../../../../components/gruppe/InputLabelGruppe';
+import { hentTittelMedNr } from '../../../../language/utils';
+import { hentTekst } from '../../../../utils/søknad';
+import {
+  EAksjeselskap,
+  IAksjeselskap,
+} from '../../../../models/steg/aktivitet/aktivitet';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { Heading } from '@navikt/ds-react';
+import { TextFieldMedBredde } from '../../../../components/TextFieldMedBredde';
+
+interface Props {
+  egetAS: IAksjeselskap[];
+  settEgetAS: (egetAS: IAksjeselskap[]) => void;
+  aksjeselskapnummer: number;
+  inkludertArbeidsmengde: boolean;
+}
+
+const Aksjeselskap: FC<Props> = ({
+  egetAS,
+  settEgetAS,
+  aksjeselskapnummer,
+  inkludertArbeidsmengde,
+}) => {
+  const intl = useLokalIntlContext();
+  const aksjeselskapFraSøknad = egetAS?.find(
+    (aksjeselskap, index) => index === aksjeselskapnummer && aksjeselskap
+  );
+  const [aksjeselskap, settAksjeselskap] = useState<IAksjeselskap>(
+    aksjeselskapFraSøknad!
+  );
+
+  useEffect(() => {
+    const endretAksjeselskap = egetAS?.map((aksjeselskapFraSøknad, index) => {
+      if (index === aksjeselskapnummer) return aksjeselskap;
+      else return aksjeselskapFraSøknad;
+    });
+    endretAksjeselskap && settEgetAS(endretAksjeselskap);
+    // eslint-disable-next-line
+  }, [aksjeselskap]);
+
+  const aksjeselskapTittel = hentTittelMedNr(
+    egetAS!,
+    aksjeselskapnummer,
+    intl.formatMessage({ id: 'egetAS.label.aksjeselskap' })
+  );
+  const navnLabel: string = hentTekst('egetAS.label.navn', intl);
+  const arbeidsmengdeLabel: string = hentTekst(
+    'arbeidsforhold.label.arbeidsmengde',
+    intl
+  );
+
+  const fjernAksjeselskap = () => {
+    if (egetAS && egetAS.length > 1) {
+      const endretAksjeselskap = egetAS?.filter(
+        (aksjeselskap, index) => aksjeselskap && index !== aksjeselskapnummer
+      );
+      endretAksjeselskap && settEgetAS(endretAksjeselskap);
+    }
+  };
+
+  const settTekstInputFelt = (
+    e: React.FormEvent<HTMLInputElement>,
+    label: string,
+    nøkkel: EAksjeselskap
+  ) => {
+    aksjeselskap &&
+      settAksjeselskap({
+        ...aksjeselskap,
+        [nøkkel]: { label: label, verdi: e.currentTarget.value },
+      });
+  };
+
+  const skalViseSlettKnapp = egetAS?.length;
+
+  return (
+    <div aria-live="polite" role="region">
+      <TittelOgSlettKnapp justify="space-between" align="center">
+        <Heading size="small" level="4" className={'tittel'}>
+          {aksjeselskapTittel}
+        </Heading>
+        {skalViseSlettKnapp && (
+          <SlettKnapp
+            onClick={() => fjernAksjeselskap()}
+            tekstid={'arbeidsforhold.knapp.slettArbeidsgiver'}
+          />
+        )}
+      </TittelOgSlettKnapp>
+      <FeltGruppe>
+        <TextFieldMedBredde
+          key={navnLabel}
+          label={navnLabel}
+          type="text"
+          bredde={'L'}
+          onChange={(e) => settTekstInputFelt(e, navnLabel, EAksjeselskap.navn)}
+          value={aksjeselskap?.navn?.verdi ? aksjeselskap.navn.verdi : ''}
+        />
+      </FeltGruppe>
+      {aksjeselskap.navn?.verdi && inkludertArbeidsmengde && (
+        <FeltGruppe>
+          <InputLabelGruppe
+            label={arbeidsmengdeLabel}
+            nøkkel={EAksjeselskap.arbeidsmengde}
+            type={'number'}
+            bredde={'XXS'}
+            value={
+              aksjeselskap?.arbeidsmengde?.verdi
+                ? aksjeselskap?.arbeidsmengde?.verdi
+                : ''
+            }
+            settInputFelt={(e) =>
+              settTekstInputFelt(
+                e,
+                arbeidsmengdeLabel,
+                EAksjeselskap.arbeidsmengde
+              )
+            }
+            beskrivendeTekst={'%'}
+          />
+        </FeltGruppe>
+      )}
+    </div>
+  );
+};
+
+export default Aksjeselskap;

--- a/src/barnetilsyn/steg/5-aktivitet/aksjeselskap/EgetAS.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/aksjeselskap/EgetAS.tsx
@@ -1,0 +1,95 @@
+import React, { FC, useEffect, useState } from 'react';
+import {
+  IAksjeselskap,
+  IAktivitet,
+} from '../../../../models/steg/aktivitet/aktivitet';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import { hentUid } from '../../../../utils/autentiseringogvalidering/uuid';
+import { nyttTekstFelt } from '../../../../helpers/tommeSøknadsfelter';
+import SeksjonGruppe from '../../../../components/gruppe/SeksjonGruppe';
+import Aksjeselskap from './Aksjeselskap';
+import { erAksjeselskapFerdigUtfylt } from '../../../../helpers/steg/aktivitetvalidering';
+import LeggTilKnapp from '../../../../components/knapper/LeggTilKnapp';
+import { Heading, Label } from '@navikt/ds-react';
+
+interface Props {
+  arbeidssituasjon: IAktivitet;
+  settArbeidssituasjon: (arbeidssituasjon: IAktivitet) => void;
+  inkludertArbeidsmengde?: boolean;
+}
+
+const tomtAksjeselskap = (inkludertArbeidsmengde: boolean): IAksjeselskap => {
+  return inkludertArbeidsmengde
+    ? {
+        id: hentUid(),
+        navn: nyttTekstFelt,
+        arbeidsmengde: nyttTekstFelt,
+      }
+    : {
+        id: hentUid(),
+        navn: nyttTekstFelt,
+      };
+};
+const EgetAS: FC<Props> = ({
+  arbeidssituasjon,
+  settArbeidssituasjon,
+  inkludertArbeidsmengde = true,
+}) => {
+  const [egetAS, settEgetAS] = useState<IAksjeselskap[]>(
+    arbeidssituasjon.egetAS
+      ? arbeidssituasjon.egetAS
+      : [tomtAksjeselskap(inkludertArbeidsmengde)]
+  );
+
+  useEffect(() => {
+    settArbeidssituasjon({ ...arbeidssituasjon, egetAS: egetAS });
+    // eslint-disable-next-line
+  }, [egetAS]);
+
+  const leggTilAksjeselskap = () => {
+    const nyttAksjeselskap: IAksjeselskap = tomtAksjeselskap(
+      inkludertArbeidsmengde
+    );
+    const arbeidsforhold: IAksjeselskap[] = egetAS;
+    arbeidsforhold.push(nyttAksjeselskap);
+    settArbeidssituasjon({ ...arbeidssituasjon, egetAS: arbeidsforhold });
+  };
+
+  return (
+    <>
+      <KomponentGruppe className={'sentrert'}>
+        <Heading size="small" level="3">
+          <LocaleTekst tekst={'egetAS.tittel'} />
+        </Heading>
+      </KomponentGruppe>
+
+      {arbeidssituasjon.egetAS?.map((aksjeselskap, index) => {
+        return (
+          <SeksjonGruppe key={index}>
+            <Aksjeselskap
+              egetAS={egetAS}
+              settEgetAS={settEgetAS}
+              aksjeselskapnummer={index}
+              inkludertArbeidsmengde={inkludertArbeidsmengde}
+            />
+          </SeksjonGruppe>
+        );
+      })}
+      {erAksjeselskapFerdigUtfylt(egetAS, inkludertArbeidsmengde) && (
+        <KomponentGruppe>
+          <FeltGruppe>
+            <Label as="p">
+              <LocaleTekst tekst={'egetAS.label.flere'} />
+            </Label>
+            <LeggTilKnapp onClick={() => leggTilAksjeselskap()}>
+              <LocaleTekst tekst={'egetAS.knapp.leggtil'} />
+            </LeggTilKnapp>
+          </FeltGruppe>
+        </KomponentGruppe>
+      )}
+    </>
+  );
+};
+export default EgetAS;

--- a/src/barnetilsyn/steg/5-aktivitet/arbeidsforhold/Arbeidsgiver.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/arbeidsforhold/Arbeidsgiver.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState } from 'react';
+import { SlettKnapp } from '../../../../components/knapper/SlettKnapp';
+import { hentTittelMedNr } from '../../../../language/utils';
+import styled from 'styled-components';
+import { hvaSlagsStilling } from './ArbeidsgiverConfig';
+import MultiSvarSpørsmål from '../../../../components/spørsmål/MultiSvarSpørsmål';
+import HarSøkerSluttdato from './HarSøkerSluttdato';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import InputLabelGruppe from '../../../../components/gruppe/InputLabelGruppe';
+import { hentTekst } from '../../../../utils/søknad';
+import {
+  EArbeidsgiver,
+  EStilling,
+  IArbeidsgiver,
+} from '../../../../models/steg/aktivitet/arbeidsgiver';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import AlertStripeDokumentasjon from '../../../../components/AlertstripeDokumentasjon';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { Heading } from '@navikt/ds-react';
+import { TextFieldMedBredde } from '../../../../components/TextFieldMedBredde';
+import { TittelOgSlettKnapp } from '../../../../components/knapper/TittelOgSlettKnapp';
+
+const StyledArbeidsgiver = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+interface Props {
+  arbeidsforhold: IArbeidsgiver[];
+  settArbeidsforhold: (arbeidsforhold: IArbeidsgiver[]) => void;
+  arbeidsgivernummer: number;
+  inkludertArbeidsmengde: boolean;
+  settDokumentasjonsbehov: (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar,
+    erHuketAv?: boolean
+  ) => void;
+}
+
+const Arbeidsgiver: React.FC<Props> = ({
+  arbeidsforhold,
+  settArbeidsforhold,
+  arbeidsgivernummer,
+  settDokumentasjonsbehov,
+  inkludertArbeidsmengde,
+}) => {
+  const intl = useLokalIntlContext();
+  const arbeidsgiverFraSøknad = arbeidsforhold?.find(
+    (arbeidsgiver, index) => index === arbeidsgivernummer && arbeidsgiver
+  );
+  const [arbeidsgiver, settArbeidsgiver] = useState<IArbeidsgiver>(
+    arbeidsgiverFraSøknad!
+  );
+
+  useEffect(() => {
+    const endretArbeidsforhold = arbeidsforhold?.map(
+      (arbeidsgiverFraSøknad, index) => {
+        if (index === arbeidsgivernummer) return arbeidsgiver;
+        else return arbeidsgiverFraSøknad;
+      }
+    );
+    endretArbeidsforhold && settArbeidsforhold(endretArbeidsforhold);
+    // eslint-disable-next-line
+  }, [arbeidsgiver]);
+
+  const settSpørsmålOgSvar = (spørsmål: ISpørsmål, svar: ISvar) => {
+    if (
+      spørsmål.søknadid === EArbeidsgiver.ansettelsesforhold &&
+      svar.id === EStilling.fast &&
+      arbeidsgiver.harSluttDato
+    ) {
+      delete arbeidsgiver.harSluttDato;
+      delete arbeidsgiver.sluttdato;
+    }
+
+    arbeidsgiver &&
+      settArbeidsgiver({
+        ...arbeidsgiver,
+        [spørsmål.søknadid]: {
+          spørsmålid: spørsmål.søknadid,
+          svarid: svar.id,
+          label: hentTekst(spørsmål.tekstid, intl),
+          verdi: svar.svar_tekst,
+        },
+      });
+    settDokumentasjonsbehov(spørsmål, svar);
+  };
+
+  const fjernArbeidsgiver = () => {
+    if (arbeidsforhold && arbeidsforhold.length > 1) {
+      const endretArbeidsforhold = arbeidsforhold?.filter(
+        (arbeidsgiver, index) => index !== arbeidsgivernummer
+      );
+      settArbeidsforhold(endretArbeidsforhold);
+    }
+  };
+
+  const settTekstInputFelt = (
+    e: React.FormEvent<HTMLInputElement>,
+    nøkkel: EArbeidsgiver,
+    label: string
+  ) => {
+    if (!e.currentTarget.value) {
+      delete arbeidsgiver.ansettelsesforhold;
+    }
+
+    arbeidsgiver &&
+      settArbeidsgiver({
+        ...arbeidsgiver,
+        [nøkkel]: { label: label, verdi: e.currentTarget.value },
+      });
+  };
+
+  const arbeidsgiverTittel = hentTittelMedNr(
+    arbeidsforhold!,
+    arbeidsgivernummer,
+    intl.formatMessage({ id: 'arbeidsforhold.tittel.arbeidsgiver' })
+  );
+  const navnLabel: string = hentTekst('arbeidsforhold.label.navn', intl);
+  const arbeidsmengdeLabel: string = hentTekst(
+    'arbeidsforhold.label.arbeidsmengde',
+    intl
+  );
+
+  const skalViseSlettKnapp = arbeidsforhold?.length > 1;
+
+  return (
+    <StyledArbeidsgiver aria-live="polite">
+      <TittelOgSlettKnapp justify="space-between" align="center">
+        <Heading size="small" level="4" className={'tittel'}>
+          {arbeidsgiverTittel}
+        </Heading>
+        {skalViseSlettKnapp && (
+          <SlettKnapp
+            onClick={() => fjernArbeidsgiver()}
+            tekstid={'arbeidsforhold.knapp.slettArbeidsgiver'}
+          />
+        )}
+      </TittelOgSlettKnapp>
+      <FeltGruppe>
+        <TextFieldMedBredde
+          key={navnLabel}
+          label={navnLabel}
+          type="text"
+          bredde={'L'}
+          value={arbeidsgiver?.navn ? arbeidsgiver.navn.verdi : ''}
+          onChange={(e) => settTekstInputFelt(e, EArbeidsgiver.navn, navnLabel)}
+        />
+      </FeltGruppe>
+      {arbeidsgiver.navn?.verdi && inkludertArbeidsmengde && (
+        <FeltGruppe>
+          <InputLabelGruppe
+            label={arbeidsmengdeLabel}
+            nøkkel={EArbeidsgiver.arbeidsmengde}
+            utvidetTekstNøkkel={
+              'arbeidsforhold.label.arbeidsmengde.beskrivelse'
+            }
+            type={'number'}
+            bredde={'XXS'}
+            settInputFelt={(e) =>
+              settTekstInputFelt(
+                e,
+                EArbeidsgiver.arbeidsmengde,
+                arbeidsmengdeLabel
+              )
+            }
+            value={
+              arbeidsgiver?.arbeidsmengde?.verdi
+                ? arbeidsgiver?.arbeidsmengde?.verdi
+                : ''
+            }
+            beskrivendeTekst={'%'}
+          />
+        </FeltGruppe>
+      )}
+      {(arbeidsgiver.arbeidsmengde?.verdi ||
+        (arbeidsgiver.navn?.verdi && !inkludertArbeidsmengde)) && (
+        <FeltGruppe>
+          <MultiSvarSpørsmål
+            spørsmål={hvaSlagsStilling(intl)}
+            settSpørsmålOgSvar={settSpørsmålOgSvar}
+            valgtSvar={arbeidsgiver.ansettelsesforhold?.verdi}
+          />
+        </FeltGruppe>
+      )}
+
+      {arbeidsgiver.ansettelsesforhold?.svarid === EStilling.lærling && (
+        <FeltGruppe>
+          <AlertStripeDokumentasjon>
+            {hentTekst('arbeidsforhold.alert.lærling', intl)}
+          </AlertStripeDokumentasjon>
+        </FeltGruppe>
+      )}
+      {arbeidsgiver.ansettelsesforhold?.svarid === EStilling.midlertidig && (
+        <HarSøkerSluttdato
+          arbeidsgiver={arbeidsgiver}
+          settArbeidsgiver={settArbeidsgiver}
+        />
+      )}
+    </StyledArbeidsgiver>
+  );
+};
+
+export default Arbeidsgiver;

--- a/src/barnetilsyn/steg/5-aktivitet/arbeidsforhold/ArbeidsgiverConfig.ts
+++ b/src/barnetilsyn/steg/5-aktivitet/arbeidsforhold/ArbeidsgiverConfig.ts
@@ -1,0 +1,48 @@
+import { ISpørsmål } from '../../../../models/felles/spørsmålogsvar';
+import {
+  EArbeidsgiver,
+  EStilling,
+} from '../../../../models/steg/aktivitet/arbeidsgiver';
+import { JaNeiSvar } from '../../../../helpers/svar';
+import { IDokumentasjon } from '../../../../models/steg/dokumentasjon';
+import { DokumentasjonsConfig } from '../../../DokumentasjonsConfig';
+import { LokalIntlShape } from '../../../../language/typer';
+
+// DOKUMENTASJON
+const DokumentasjonLærling: IDokumentasjon =
+  DokumentasjonsConfig.DokumentasjonLærling;
+
+// SPØRSMÅL
+export const hvaSlagsStilling = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EArbeidsgiver.ansettelsesforhold,
+  tekstid: 'arbeidsforhold.label.ansettelsesforhold',
+  flersvar: false,
+  svaralternativer: [
+    {
+      id: EStilling.fast,
+      svar_tekst: intl.formatMessage({ id: 'arbeidsforhold.svar.fast' }),
+    },
+    {
+      id: EStilling.midlertidig,
+      svar_tekst: intl.formatMessage({ id: 'arbeidsforhold.svar.midlertidig' }),
+    },
+    {
+      id: EStilling.lærling,
+      svar_tekst: intl.formatMessage({ id: 'arbeidsforhold.svar.lærling' }),
+      dokumentasjonsbehov: DokumentasjonLærling,
+    },
+    {
+      id: EStilling.tilkallingsvakt,
+      svar_tekst: intl.formatMessage({
+        id: 'arbeidsforhold.svar.tilkallingsvakt',
+      }),
+    },
+  ],
+});
+
+export const harDuSluttdato = (intl: LokalIntlShape): ISpørsmål => ({
+  søknadid: EArbeidsgiver.harSluttDato,
+  tekstid: 'arbeidsforhold.label.sluttdato',
+  flersvar: false,
+  svaralternativer: JaNeiSvar(intl),
+});

--- a/src/barnetilsyn/steg/5-aktivitet/arbeidsforhold/HarSøkerSluttdato.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/arbeidsforhold/HarSøkerSluttdato.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import JaNeiSpørsmål from '../../../../components/spørsmål/JaNeiSpørsmål';
+import { harDuSluttdato } from './ArbeidsgiverConfig';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import {
+  Datovelger,
+  DatoBegrensning,
+} from '../../../../components/dato/Datovelger';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import {
+  EArbeidsgiver,
+  IArbeidsgiver,
+} from '../../../../models/steg/aktivitet/arbeidsgiver';
+import { hentBooleanFraValgtSvar } from '../../../../utils/spørsmålogsvar';
+import { hentTekst } from '../../../../utils/søknad';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+
+interface Props {
+  arbeidsgiver: IArbeidsgiver;
+  settArbeidsgiver: (arbeidsgiver: IArbeidsgiver) => void;
+}
+
+const HarSøkerSluttdato: React.FC<Props> = ({
+  arbeidsgiver,
+  settArbeidsgiver,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const settDato = (dato: string) => {
+    dato !== null &&
+      settArbeidsgiver({
+        ...arbeidsgiver,
+        [EArbeidsgiver.sluttdato]: {
+          label: hentTekst(sluttdatoTekstid, intl),
+          verdi: dato,
+        },
+      });
+  };
+
+  const settHarSluttDato = (spørsmål: ISpørsmål, valgtSvar: ISvar) => {
+    const svar: boolean = hentBooleanFraValgtSvar(valgtSvar);
+    const harSluttDatoFelt = {
+      spørsmålid: spørsmål.søknadid,
+      svarid: valgtSvar.id,
+      label: hentTekst(spørsmål.tekstid, intl),
+      verdi: svar,
+    };
+    if (svar === false && arbeidsgiver.sluttdato) {
+      const endretArbeidsgiver = arbeidsgiver;
+      delete endretArbeidsgiver.sluttdato;
+      settArbeidsgiver({
+        ...endretArbeidsgiver,
+        [EArbeidsgiver.harSluttDato]: harSluttDatoFelt,
+      });
+    } else {
+      settArbeidsgiver({
+        ...arbeidsgiver,
+        [EArbeidsgiver.harSluttDato]: harSluttDatoFelt,
+      });
+    }
+  };
+
+  const sluttdatoTekstid = 'arbeidsforhold.datovelger.sluttdato';
+
+  return (
+    <>
+      <KomponentGruppe>
+        <FeltGruppe>
+          <JaNeiSpørsmål
+            spørsmål={harDuSluttdato(intl)}
+            onChange={settHarSluttDato}
+            valgtSvar={arbeidsgiver.harSluttDato?.verdi}
+          />
+        </FeltGruppe>
+        {arbeidsgiver.harSluttDato?.verdi === true && (
+          <FeltGruppe>
+            <Datovelger
+              valgtDato={arbeidsgiver.sluttdato?.verdi}
+              tekstid={sluttdatoTekstid}
+              datobegrensning={DatoBegrensning.FremtidigeDatoer}
+              settDato={(e) => settDato(e)}
+            />
+          </FeltGruppe>
+        )}
+      </KomponentGruppe>
+    </>
+  );
+};
+
+export default HarSøkerSluttdato;

--- a/src/barnetilsyn/steg/5-aktivitet/arbeidsforhold/OmArbeidsforholdetDitt.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/arbeidsforhold/OmArbeidsforholdetDitt.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+import Arbeidsgiver from './Arbeidsgiver';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import SeksjonGruppe from '../../../../components/gruppe/SeksjonGruppe';
+import { IAktivitet } from '../../../../models/steg/aktivitet/aktivitet';
+import { IArbeidsgiver } from '../../../../models/steg/aktivitet/arbeidsgiver';
+import { nyttTekstFelt } from '../../../../helpers/tommeSøknadsfelter';
+import { hentUid } from '../../../../utils/autentiseringogvalidering/uuid';
+import { erSisteArbeidsgiverFerdigUtfylt } from '../../../../helpers/steg/aktivitetvalidering';
+import LeggTilKnapp from '../../../../components/knapper/LeggTilKnapp';
+import { ISpørsmål, ISvar } from '../../../../models/felles/spørsmålogsvar';
+import { Heading, Label } from '@navikt/ds-react';
+
+interface Props {
+  arbeidssituasjon: IAktivitet;
+  settArbeidssituasjon: (nyArbeidssituasjon: IAktivitet) => void;
+  settDokumentasjonsbehov: (
+    spørsmål: ISpørsmål,
+    valgtSvar: ISvar,
+    erHuketAv?: boolean
+  ) => void;
+  inkludertArbeidsmengde?: boolean;
+}
+
+const tomArbeidsgiver = (inkludertArbeidsmengde: boolean): IArbeidsgiver => {
+  return inkludertArbeidsmengde
+    ? {
+        id: hentUid(),
+        navn: nyttTekstFelt,
+        arbeidsmengde: nyttTekstFelt,
+      }
+    : {
+        id: hentUid(),
+        navn: nyttTekstFelt,
+      };
+};
+
+const OmArbeidsforholdetDitt: React.FC<Props> = ({
+  arbeidssituasjon,
+  settArbeidssituasjon,
+  settDokumentasjonsbehov,
+  inkludertArbeidsmengde = true,
+}) => {
+  const [arbeidsforhold, settArbeidsforhold] = useState<IArbeidsgiver[]>(
+    arbeidssituasjon.arbeidsforhold
+      ? arbeidssituasjon.arbeidsforhold
+      : [tomArbeidsgiver(inkludertArbeidsmengde)]
+  );
+
+  useEffect(() => {
+    settArbeidssituasjon({
+      ...arbeidssituasjon,
+      arbeidsforhold: arbeidsforhold,
+    });
+    // eslint-disable-next-line
+  }, [arbeidsforhold]);
+
+  const leggTilArbeidsgiver = () => {
+    const nyArbeidsgiver: IArbeidsgiver = tomArbeidsgiver(
+      inkludertArbeidsmengde
+    );
+    const alleArbeidsgivere = arbeidsforhold;
+    alleArbeidsgivere.push(nyArbeidsgiver);
+    settArbeidssituasjon({
+      ...arbeidssituasjon,
+      arbeidsforhold: alleArbeidsgivere,
+    });
+  };
+
+  return (
+    <>
+      <KomponentGruppe className={'sentrert'}>
+        <Heading size="small" level="3">
+          <LocaleTekst tekst={'arbeidsforhold.tittel'} />
+        </Heading>
+      </KomponentGruppe>
+      {arbeidssituasjon.arbeidsforhold?.map((arbeidsgiver, index) => {
+        return (
+          <SeksjonGruppe key={arbeidsgiver.id}>
+            <Arbeidsgiver
+              arbeidsforhold={arbeidsforhold}
+              settArbeidsforhold={settArbeidsforhold}
+              arbeidsgivernummer={index}
+              settDokumentasjonsbehov={settDokumentasjonsbehov}
+              inkludertArbeidsmengde={inkludertArbeidsmengde}
+            />
+          </SeksjonGruppe>
+        );
+      })}
+
+      {erSisteArbeidsgiverFerdigUtfylt(arbeidsforhold) && (
+        <KomponentGruppe>
+          <FeltGruppe>
+            <Label as="p">
+              <LocaleTekst tekst={'arbeidsforhold.label.flereArbeidsgivere'} />
+            </Label>
+            <LeggTilKnapp onClick={() => leggTilArbeidsgiver()}>
+              <LocaleTekst tekst={'arbeidsforhold.knapp.leggTilArbeidsgiver'} />
+            </LeggTilKnapp>
+          </FeltGruppe>
+        </KomponentGruppe>
+      )}
+    </>
+  );
+};
+
+export default OmArbeidsforholdetDitt;

--- a/src/barnetilsyn/steg/5-aktivitet/firma/OmFirmaeneDine.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/firma/OmFirmaeneDine.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import SeksjonGruppe from '../../../../components/gruppe/SeksjonGruppe';
+import { IAktivitet } from '../../../../models/steg/aktivitet/aktivitet';
+import { nyttTekstFelt } from '../../../../helpers/tommeSøknadsfelter';
+import { hentUid } from '../../../../utils/autentiseringogvalidering/uuid';
+import { erSisteFirmaUtfylt } from '../../../../helpers/steg/aktivitetvalidering';
+import LeggTilKnapp from '../../../../components/knapper/LeggTilKnapp';
+import { IFirma } from '../../../../models/steg/aktivitet/firma';
+import OmFirmaetDitt from './OmFirmaetDitt';
+import { Heading, Label } from '@navikt/ds-react';
+
+interface Props {
+  arbeidssituasjon: IAktivitet;
+  settArbeidssituasjon: (nyArbeidssituasjon: IAktivitet) => void;
+  inkludertArbeidsmengde?: boolean;
+  overskuddsår: number;
+}
+
+const tomtFirma = (inkludertArbeidsmengde: boolean): IFirma => {
+  return inkludertArbeidsmengde
+    ? {
+        id: hentUid(),
+        navn: nyttTekstFelt,
+        arbeidsmengde: nyttTekstFelt,
+      }
+    : {
+        id: hentUid(),
+        navn: nyttTekstFelt,
+      };
+};
+
+const OmFirmaeneDine: React.FC<Props> = ({
+  arbeidssituasjon,
+  settArbeidssituasjon,
+  inkludertArbeidsmengde = true,
+  overskuddsår,
+}) => {
+  const [firmaer, settFirmaer] = useState<IFirma[]>(
+    arbeidssituasjon.firmaer
+      ? arbeidssituasjon.firmaer
+      : [tomtFirma(inkludertArbeidsmengde)]
+  );
+
+  useEffect(() => {
+    settArbeidssituasjon({
+      ...arbeidssituasjon,
+      firmaer: firmaer,
+    });
+    // eslint-disable-next-line
+  }, [firmaer]);
+
+  const leggTilFirma = () => {
+    const nyttFirma: IFirma = tomtFirma(inkludertArbeidsmengde);
+
+    settFirmaer([...firmaer, nyttFirma]);
+  };
+
+  return (
+    <>
+      <KomponentGruppe className={'sentrert'}>
+        <Heading size="small" level="3">
+          <LocaleTekst tekst={'firmaer.tittel'} />
+        </Heading>
+      </KomponentGruppe>
+      {firmaer?.map((firma, index) => {
+        return (
+          <SeksjonGruppe key={firma.id}>
+            <OmFirmaetDitt
+              firmaer={firmaer}
+              settFirmaer={settFirmaer}
+              firmanr={index}
+              inkludertArbeidsmengde={inkludertArbeidsmengde}
+              overskuddsår={overskuddsår}
+            />
+          </SeksjonGruppe>
+        );
+      })}
+
+      {erSisteFirmaUtfylt(firmaer) && (
+        <KomponentGruppe>
+          <FeltGruppe>
+            <Label as="p">
+              <LocaleTekst tekst={'firmaer.label.flereFirmaer'} />
+            </Label>
+            <LeggTilKnapp onClick={() => leggTilFirma()}>
+              <LocaleTekst tekst={'firmaer.knapp.leggTilFirma'} />
+            </LeggTilKnapp>
+          </FeltGruppe>
+        </KomponentGruppe>
+      )}
+    </>
+  );
+};
+
+export default OmFirmaeneDine;

--- a/src/barnetilsyn/steg/5-aktivitet/firma/OmFirmaetDitt.tsx
+++ b/src/barnetilsyn/steg/5-aktivitet/firma/OmFirmaetDitt.tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Datovelger,
+  DatoBegrensning,
+} from '../../../../components/dato/Datovelger';
+import InputLabelGruppe from '../../../../components/gruppe/InputLabelGruppe';
+import FeltGruppe from '../../../../components/gruppe/FeltGruppe';
+import { EFirma, IFirma } from '../../../../models/steg/aktivitet/firma';
+import { hentTekst } from '../../../../utils/søknad';
+import { hentTittelMedNr } from '../../../../language/utils';
+import { SlettKnapp } from '../../../../components/knapper/SlettKnapp';
+import styled from 'styled-components';
+import LocaleTekst from '../../../../language/LocaleTekst';
+import { erStrengGyldigOrganisasjonsnummer } from '../../../../utils/autentiseringogvalidering/feltvalidering';
+import { erDatoGyldigOgInnaforBegrensninger } from '../../../../components/dato/utils';
+import { TittelOgSlettKnapp } from '../../../../components/knapper/TittelOgSlettKnapp';
+import { useLokalIntlContext } from '../../../../context/LokalIntlContext';
+import { ErrorMessage, Heading, Label, Textarea } from '@navikt/ds-react';
+import { TextFieldMedBredde } from '../../../../components/TextFieldMedBredde';
+import { hentBeskjedMedNavn } from '../../../../utils/språk';
+import LesMerTekst from '../../../../components/LesMerTekst';
+
+const StyledFirma = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+interface Props {
+  firmaer: IFirma[];
+  firmanr: number;
+  settFirmaer: (firmaer: IFirma[]) => void;
+  inkludertArbeidsmengde?: boolean;
+  overskuddsår: number;
+}
+
+const OmFirmaetDitt: React.FC<Props> = ({
+  firmaer,
+  firmanr,
+  settFirmaer,
+  inkludertArbeidsmengde = true,
+  overskuddsår,
+}) => {
+  const intl = useLokalIntlContext();
+  const firmaFraSøknad = firmaer?.find((firma, index) => index === firmanr);
+
+  const [firma, settFirma] = useState<IFirma>(firmaFraSøknad!);
+  const [organisasjonsnummer, settOrganisasjonsnr] = useState<string>(
+    firma.organisasjonsnummer?.verdi ? firma.organisasjonsnummer.verdi : ''
+  );
+
+  useEffect(() => {
+    const endredeFirmaer = firmaer?.map((firmaFraSøknad, index) => {
+      return index === firmanr ? firma : firmaFraSøknad;
+    });
+
+    settFirmaer(endredeFirmaer);
+    // eslint-disable-next-line
+  }, [firma]);
+
+  const settDatoFelt = (dato: string): void => {
+    dato !== null &&
+      settFirma({
+        ...firma,
+        etableringsdato: {
+          label: hentTekst('firma.datovelger.etablering', intl),
+          verdi: dato,
+        },
+      });
+  };
+
+  const settArbeidsukeTekst = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ): void => {
+    settFirma({
+      ...firma,
+      arbeidsuke: {
+        label: hentTekst('firma.label.arbeidsuke', intl),
+        verdi: e.target.value,
+      },
+    });
+  };
+
+  const settInputTekstFelt = (
+    e: React.FormEvent<HTMLInputElement>,
+    nøkkel: EFirma,
+    label: string
+  ) => {
+    settFirma({
+      ...firma,
+      [nøkkel]: { label: label, verdi: e.currentTarget.value },
+    });
+  };
+
+  const fjernFirma = () => {
+    if (firmaer && firmaer.length > 1) {
+      const oppdaterteFirmaer = firmaer?.filter(
+        (arbeidsgiver, index) => index !== firmanr
+      );
+      settFirmaer(oppdaterteFirmaer);
+    }
+  };
+
+  const labelArbeidsmengde = hentTekst('firma.label.arbeidsmengde', intl);
+  const labelArbeidsuke = hentTekst('firma.label.arbeidsuke', intl);
+  const labelOverskudd = hentBeskjedMedNavn(
+    `${overskuddsår}`,
+    hentTekst('firma.label.overskudd', intl)
+  );
+  const labelOrganisasjonsnr = hentTekst('firma.label.organisasjonnr', intl);
+  const labelNavn = hentTekst('firma.label.navn', intl);
+  const firmaTittel = hentTittelMedNr(
+    firmaer!,
+    firmanr,
+    intl.formatMessage({ id: 'firma.tittel' })
+  );
+  const harValgtUgyldigOrganisasjonsnummer =
+    organisasjonsnummer !== '' &&
+    firma?.organisasjonsnummer?.verdi &&
+    !erStrengGyldigOrganisasjonsnummer(firma?.organisasjonsnummer?.verdi);
+
+  const skalViseSlettKnapp = firmaer?.length > 1;
+
+  return (
+    <StyledFirma aria-live="polite">
+      <TittelOgSlettKnapp justify="space-between" align="center">
+        <Heading size="small" level="4" className={'tittel'}>
+          {firmaTittel}
+        </Heading>
+        {skalViseSlettKnapp && (
+          <SlettKnapp
+            onClick={() => fjernFirma()}
+            tekstid={'firma.knapp.slett'}
+          />
+        )}
+      </TittelOgSlettKnapp>
+      <FeltGruppe>
+        <TextFieldMedBredde
+          label={labelNavn}
+          bredde={'L'}
+          type={'text'}
+          onChange={(e) => settInputTekstFelt(e, EFirma.navn, labelNavn)}
+          value={firma?.navn ? firma?.navn.verdi : ''}
+        />
+      </FeltGruppe>
+
+      {firma.navn?.verdi && (
+        <>
+          <FeltGruppe>
+            <TextFieldMedBredde
+              label={labelOrganisasjonsnr}
+              bredde={'XS'}
+              type={'text'}
+              onChange={(e) => settOrganisasjonsnr(e.target.value)}
+              onBlur={(e) =>
+                settInputTekstFelt(
+                  e,
+                  EFirma.organisasjonsnummer,
+                  labelOrganisasjonsnr
+                )
+              }
+              value={organisasjonsnummer ? organisasjonsnummer : ''}
+              error={harValgtUgyldigOrganisasjonsnummer}
+            />
+          </FeltGruppe>
+          {harValgtUgyldigOrganisasjonsnummer && (
+            <FeltGruppe>
+              <ErrorMessage>
+                <LocaleTekst tekst={'firma.feilmelding.organisasjonnr'} />
+              </ErrorMessage>
+            </FeltGruppe>
+          )}
+        </>
+      )}
+
+      {erStrengGyldigOrganisasjonsnummer(firma.organisasjonsnummer?.verdi) && (
+        <FeltGruppe>
+          <Datovelger
+            valgtDato={firma?.etableringsdato?.verdi}
+            tekstid={'firma.datovelger.etablering'}
+            datobegrensning={DatoBegrensning.TidligereDatoer}
+            settDato={(e) => settDatoFelt(e)}
+          />
+        </FeltGruppe>
+      )}
+
+      {firma.etableringsdato?.verdi &&
+        erDatoGyldigOgInnaforBegrensninger(
+          firma.etableringsdato?.verdi,
+          DatoBegrensning.TidligereDatoer
+        ) &&
+        inkludertArbeidsmengde && (
+          <FeltGruppe>
+            <InputLabelGruppe
+              label={labelArbeidsmengde}
+              nøkkel={labelArbeidsmengde}
+              type={'number'}
+              bredde={'XXS'}
+              settInputFelt={(e) =>
+                settInputTekstFelt(e, EFirma.arbeidsmengde, labelArbeidsmengde)
+              }
+              beskrivendeTekst={'%'}
+              value={
+                firma?.arbeidsmengde?.verdi ? firma?.arbeidsmengde?.verdi : ''
+              }
+            />
+          </FeltGruppe>
+        )}
+
+      {(firma.arbeidsmengde?.verdi ||
+        (!inkludertArbeidsmengde && firma.etableringsdato?.verdi)) && (
+        <>
+          <FeltGruppe>
+            <Label as={'label'} htmlFor={labelArbeidsuke}>
+              {labelArbeidsuke}
+            </Label>
+            <LesMerTekst
+              åpneTekstid={''}
+              innholdTekstid={'firma.lesmer-innhold.arbeidsuke'}
+            />
+            <Textarea
+              autoComplete={'off'}
+              key={labelArbeidsuke}
+              label={labelArbeidsuke}
+              hideLabel={true}
+              value={firma.arbeidsuke?.verdi ? firma.arbeidsuke?.verdi : ''}
+              maxLength={1000}
+              onChange={(e) => settArbeidsukeTekst(e)}
+            />
+          </FeltGruppe>
+          <FeltGruppe>
+            <InputLabelGruppe
+              hjelpetekst={{
+                headerTekstid: '',
+                innholdTekstid: 'firma.lesmer-innhold.overskudd',
+              }}
+              label={labelOverskudd}
+              nøkkel={labelOverskudd}
+              type={'number'}
+              bredde={'XS'}
+              settInputFelt={(e) =>
+                settInputTekstFelt(e, EFirma.overskudd, labelOverskudd)
+              }
+              beskrivendeTekst={'kroner'}
+              value={firma?.overskudd?.verdi ? firma?.overskudd?.verdi : ''}
+            />
+          </FeltGruppe>
+        </>
+      )}
+    </StyledFirma>
+  );
+};
+
+export default OmFirmaetDitt;

--- a/src/barnetilsyn/steg/6-barnepass/BarnepassConfig.tsx
+++ b/src/barnetilsyn/steg/6-barnepass/BarnepassConfig.tsx
@@ -6,8 +6,8 @@ import {
   EÅrsakBarnepass,
 } from '../../models/barnepass';
 import { ESøkerFraBestemtMåned } from '../../../models/steg/dinsituasjon/meromsituasjon';
-import { DokumentasjonsConfig } from '../../../søknad/DokumentasjonsConfig';
 import { LokalIntlShape } from '../../../language/typer';
+import { DokumentasjonsConfig } from '../../DokumentasjonsConfig';
 
 // ----- DOKUMENTASJON
 

--- a/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/Oppsummering.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
-import OppsummeringAktiviteter from '../../../søknad/steg/7-oppsummering/OppsummeringAktiviteter';
-import OppsummeringBarnaDine from '../../../søknad/steg/7-oppsummering/OppsummeringBarnaDine';
-import OppsummeringBarnasBosituasjon from '../../../søknad/steg/7-oppsummering/OppsummeringBarnasBosituasjon';
 import OppsummeringBarnepass from './OppsummeringBarnepass';
-import OppsummeringBosituasionenDin from '../../../søknad/steg/7-oppsummering/OppsummeringBosituasjon';
-import OppsummeringOmDeg from '../../../søknad/steg/7-oppsummering/OppsummeringOmDeg';
 import {
   ERouteBarnetilsyn,
   RoutesBarnetilsyn,
@@ -20,6 +15,11 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
 import { Accordion, BodyShort } from '@navikt/ds-react';
+import OppsummeringAktiviteter from './OppsummeringAktiviteter';
+import OppsummeringBarnaDine from './OppsummeringBarnaDine';
+import OppsummeringBarnasBosituasjon from './OppsummeringBarnasBosituasjon';
+import OppsummeringBosituasionenDin from './OppsummeringBosituasjon';
+import OppsummeringOmDeg from './OppsummeringOmDeg';
 
 const Oppsummering: React.FC = () => {
   const intl = useLokalIntlContext();

--- a/src/barnetilsyn/steg/7-oppsummering/OppsummeringAktiviteter.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/OppsummeringAktiviteter.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import endre from '../../../assets/endre.svg';
+import LenkeMedIkon from '../../../components/knapper/LenkeMedIkon';
+import { hentTekst } from '../../../utils/søknad';
+import { IAktivitet } from '../../../models/steg/aktivitet/aktivitet';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import {
+  VisLabelOgSvar,
+  visLabelOgVerdiForSpørsmålFelt,
+  visLabelOgVerdiForSpørsmålListeFelt,
+  visListeAvLabelOgSvar,
+} from '../../../utils/visning';
+import {
+  SeksjonSpacingBottom,
+  SeksjonSpacingTop,
+  StyledOppsummeringMedUndertitler,
+} from '../../../components/stegKomponenter/StyledOppsummering';
+import { useNavigate } from 'react-router-dom';
+import { Ingress } from '@navikt/ds-react';
+
+interface Props {
+  aktivitet: IAktivitet;
+  endreInformasjonPath?: string;
+}
+
+const OppsummeringAktiviteter: React.FC<Props> = ({
+  aktivitet,
+  endreInformasjonPath,
+}) => {
+  const navigate = useNavigate();
+  const intl = useLokalIntlContext();
+
+  return (
+    <StyledOppsummeringMedUndertitler>
+      {aktivitet.erIArbeid &&
+        visLabelOgVerdiForSpørsmålFelt(aktivitet?.erIArbeid, intl)}
+
+      {aktivitet.hvaErDinArbeidssituasjon && (
+        <SeksjonSpacingBottom>
+          {visLabelOgVerdiForSpørsmålListeFelt(
+            aktivitet.hvaErDinArbeidssituasjon
+          )}
+        </SeksjonSpacingBottom>
+      )}
+
+      {aktivitet.etablererEgenVirksomhet && (
+        <SeksjonSpacingBottom>
+          {visLabelOgVerdiForSpørsmålFelt(
+            aktivitet.etablererEgenVirksomhet,
+            intl,
+            hentTekst('arbeidssituasjon.tittel.etablererEgenVirksomhet', intl)
+          )}
+        </SeksjonSpacingBottom>
+      )}
+
+      {aktivitet.arbeidsforhold && (
+        <SeksjonSpacingBottom>
+          {visListeAvLabelOgSvar(
+            aktivitet.arbeidsforhold,
+            hentTekst('arbeidsforhold.tittel.arbeidsgiver', intl)
+          )}
+        </SeksjonSpacingBottom>
+      )}
+
+      {aktivitet.firmaer && (
+        <SeksjonSpacingBottom>
+          {visListeAvLabelOgSvar(
+            aktivitet.firmaer,
+            hentTekst('firmaer.tittel', intl)
+          )}
+        </SeksjonSpacingBottom>
+      )}
+
+      {aktivitet.egetAS && (
+        <SeksjonSpacingBottom>
+          {visListeAvLabelOgSvar(
+            aktivitet.egetAS,
+            hentTekst('arbeidsforhold.tittel.egetAS', intl)
+          )}
+        </SeksjonSpacingBottom>
+      )}
+
+      {aktivitet.arbeidssøker && (
+        <SeksjonSpacingBottom>
+          <Ingress>{hentTekst('arbeidssøker.tittel', intl)}</Ingress>
+          {VisLabelOgSvar(aktivitet.arbeidssøker)}
+        </SeksjonSpacingBottom>
+      )}
+
+      {aktivitet.underUtdanning && (
+        <SeksjonSpacingBottom>
+          <Ingress>{hentTekst('utdanning.tittel', intl)}</Ingress>
+          {VisLabelOgSvar(aktivitet.underUtdanning)}
+          {aktivitet.underUtdanning?.tidligereUtdanning && (
+            <SeksjonSpacingTop>
+              {visListeAvLabelOgSvar(
+                aktivitet.underUtdanning.tidligereUtdanning,
+                hentTekst('utdanning.tittel.tidligere', intl)
+              )}
+            </SeksjonSpacingTop>
+          )}
+        </SeksjonSpacingBottom>
+      )}
+      <LenkeMedIkon
+        onClick={() =>
+          navigate(
+            { pathname: endreInformasjonPath },
+            { state: { kommerFraOppsummering: true }, replace: true }
+          )
+        }
+        tekst_id="barnasbosted.knapp.endre"
+        ikon={endre}
+      />
+    </StyledOppsummeringMedUndertitler>
+  );
+};
+
+export default OppsummeringAktiviteter;

--- a/src/barnetilsyn/steg/7-oppsummering/OppsummeringBarn.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/OppsummeringBarn.tsx
@@ -1,0 +1,90 @@
+import { FC } from 'react';
+import { IBarn } from '../../../models/steg/barn';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import { verdiTilTekstsvar } from '../../../utils/visning';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import LocaleTekst from '../../../language/LocaleTekst';
+import { BodyShort, Label } from '@navikt/ds-react';
+
+interface Props {
+  stønadstype: Stønadstype;
+  barn: IBarn;
+}
+
+const OppsummeringBarn: FC<Props> = ({ stønadstype, barn }) => {
+  const intl = useLokalIntlContext();
+  const {
+    alder,
+    ident,
+    navn,
+    født,
+    skalHaBarnepass,
+    harSammeAdresse,
+    lagtTil,
+    harAdressesperre,
+  } = barn;
+
+  return (
+    <>
+      {!harAdressesperre && navn && (
+        <div className={'spørsmål-og-svar'}>
+          <Label as="p">
+            <LocaleTekst tekst="person.navn" />
+          </Label>
+          <BodyShort>{navn.verdi}</BodyShort>
+        </div>
+      )}
+
+      {!harAdressesperre && ident && ident.verdi !== '' && (
+        <div className={'spørsmål-og-svar'}>
+          <Label as="p">
+            <LocaleTekst tekst="person.fnr" />
+          </Label>
+          <BodyShort>{ident.verdi}</BodyShort>
+        </div>
+      )}
+
+      {alder && (
+        <div className={'spørsmål-og-svar'}>
+          <Label as="p">
+            <LocaleTekst tekst="person.alder" />
+          </Label>
+          <BodyShort>{alder.verdi}</BodyShort>
+        </div>
+      )}
+
+      {født?.verdi && lagtTil && (
+        <div className={'spørsmål-og-svar'}>
+          <Label as="p">
+            <LocaleTekst tekst="barnekort.spm.født" />
+          </Label>
+          <BodyShort>{verdiTilTekstsvar(født.verdi, intl)}</BodyShort>
+        </div>
+      )}
+
+      {stønadstype === Stønadstype.barnetilsyn && skalHaBarnepass && (
+        <div className={'spørsmål-og-svar'}>
+          <Label as="p">
+            <LocaleTekst tekst="barnekort.skalHaBarnepass" />
+          </Label>
+          <BodyShort>
+            {verdiTilTekstsvar(skalHaBarnepass?.verdi, intl)}
+          </BodyShort>
+        </div>
+      )}
+
+      {!harAdressesperre && harSammeAdresse && (
+        <div className={'spørsmål-og-svar'}>
+          <Label as="p">
+            <LocaleTekst tekst="barnekort.spm.sammeAdresse" />
+          </Label>
+          <BodyShort>
+            {verdiTilTekstsvar(harSammeAdresse.verdi, intl)}
+          </BodyShort>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default OppsummeringBarn;

--- a/src/barnetilsyn/steg/7-oppsummering/OppsummeringBarnaDine.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/OppsummeringBarnaDine.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import endre from '../../../assets/endre.svg';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import LenkeMedIkon from '../../../components/knapper/LenkeMedIkon';
+import { hentTekst } from '../../../utils/søknad';
+import { IBarn } from '../../../models/steg/barn';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import BarneHeader from '../../../components/BarneHeader';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { StyledOppsummeringForBarn } from '../../../components/stegKomponenter/StyledOppsummering';
+import { useNavigate } from 'react-router-dom';
+import OppsummeringBarn from './OppsummeringBarn';
+
+interface Props {
+  barn: IBarn[];
+  stønadstype: Stønadstype;
+  endreInformasjonPath?: string;
+}
+
+const OppsummeringBarnaDine: React.FC<Props> = ({
+  barn,
+  stønadstype,
+  endreInformasjonPath,
+}) => {
+  const intl = useLokalIntlContext();
+  const navigate = useNavigate();
+  const barnaDine: IBarn[] = barn;
+
+  const hentEndretBarn = (barn: IBarn): IBarn => {
+    const nyttBarn = { ...barn };
+
+    if (barn && !barn?.født?.verdi) {
+      // @ts-expect-error sletting
+      delete nyttBarn?.ident;
+      // @ts-expect-error sletting
+      delete nyttBarn.navn;
+      // @ts-expect-error sletting
+      delete nyttBarn.alder;
+
+      nyttBarn.fødselsdato = {
+        label: hentTekst('barnadine.termindato', intl),
+        verdi: barn.fødselsdato.verdi,
+      };
+    }
+    return nyttBarn;
+  };
+  const oppsummeringBarnaDine = barnaDine
+    .filter((barn) =>
+      stønadstype == Stønadstype.barnetilsyn
+        ? barn.skalHaBarnepass?.verdi
+        : true
+    )
+    .map((barn) => {
+      const endretBarn = hentEndretBarn(barn);
+
+      return (
+        <StyledOppsummeringForBarn key={barn.id}>
+          <BarneHeader barn={barn} />
+          <OppsummeringBarn stønadstype={stønadstype} barn={endretBarn} />
+        </StyledOppsummeringForBarn>
+      );
+    });
+
+  return (
+    <>
+      <KomponentGruppe>{oppsummeringBarnaDine}</KomponentGruppe>
+      <LenkeMedIkon
+        onClick={() =>
+          navigate(
+            { pathname: endreInformasjonPath },
+            { state: { kommerFraOppsummering: true } }
+          )
+        }
+        tekst_id="barnasbosted.knapp.endre"
+        ikon={endre}
+      />
+    </>
+  );
+};
+
+export default OppsummeringBarnaDine;

--- a/src/barnetilsyn/steg/7-oppsummering/OppsummeringBarnasBosituasjon.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/OppsummeringBarnasBosituasjon.tsx
@@ -1,0 +1,85 @@
+import { FC } from 'react';
+import endre from '../../../assets/endre.svg';
+import LenkeMedIkon from '../../../components/knapper/LenkeMedIkon';
+import { IBarn } from '../../../models/steg/barn';
+import { VisLabelOgSvar } from '../../../utils/visning';
+import BarneHeader from '../../../components/BarneHeader';
+import { StyledOppsummeringForBarn } from '../../../components/stegKomponenter/StyledOppsummering';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { hentTekst } from '../../../utils/søknad';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { useNavigate } from 'react-router-dom';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
+
+interface Props {
+  barn: IBarn[];
+  endreInformasjonPath?: string;
+  stønadstype: Stønadstype;
+}
+
+const OppsummeringBarnasBosituasjon: FC<Props> = ({
+  barn,
+  endreInformasjonPath,
+  stønadstype,
+}) => {
+  const navigate = useNavigate();
+  const intl = useLokalIntlContext();
+
+  const felterAlleForeldrene = barn
+    .filter((barn) =>
+      stønadstype == Stønadstype.barnetilsyn
+        ? barn.skalHaBarnepass?.verdi
+        : true
+    )
+    .map((barn) => {
+      if (!barn.forelder) return null;
+
+      const visningsIdent = barn.forelder.fraFolkeregister
+        ? undefined
+        : barn.forelder.ident;
+
+      const visningForelder = {
+        ...barn.forelder,
+        navn: {
+          label: hentTekst('barnasbosted.oppsummering.navn.label', intl),
+          verdi: barn.forelder?.navn?.verdi,
+        },
+        ident: visningsIdent,
+      };
+
+      delete visningForelder.hvorforIkkeOppgi;
+      delete visningForelder.kanIkkeOppgiAnnenForelderFar;
+
+      const barnetsNavn =
+        barn.født?.verdi && barn.navn.verdi
+          ? barn.navn.verdi
+          : hentTekst('barnet.litenForBokstav', intl);
+
+      const forelderFelter = VisLabelOgSvar(visningForelder, barnetsNavn);
+
+      return (
+        <StyledOppsummeringForBarn key={barn.id}>
+          <BarneHeader barn={barn} />
+          {forelderFelter}
+        </StyledOppsummeringForBarn>
+      );
+    });
+
+  return (
+    <>
+      <KomponentGruppe>{felterAlleForeldrene}</KomponentGruppe>
+      <LenkeMedIkon
+        onClick={() =>
+          navigate(
+            { pathname: endreInformasjonPath },
+            { state: { kommerFraOppsummering: true } }
+          )
+        }
+        tekst_id="barnasbosted.knapp.endre"
+        ikon={endre}
+      />
+    </>
+  );
+};
+
+export default OppsummeringBarnasBosituasjon;

--- a/src/barnetilsyn/steg/7-oppsummering/OppsummeringBosituasjon.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/OppsummeringBosituasjon.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import endre from '../../../assets/endre.svg';
+import LenkeMedIkon from '../../../components/knapper/LenkeMedIkon';
+import { hentTekst } from '../../../utils/søknad';
+import {
+  ESøkerDelerBolig,
+  IBosituasjon,
+} from '../../../models/steg/bosituasjon';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { VisLabelOgSvar } from '../../../utils/visning';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { StyledOppsummering } from '../../../components/stegKomponenter/StyledOppsummering';
+import { useNavigate } from 'react-router-dom';
+import { Ingress } from '@navikt/ds-react';
+
+interface Props {
+  bosituasjon: IBosituasjon;
+  endreInformasjonPath?: string;
+}
+
+const OppsummeringBosituasionenDin: React.FC<Props> = ({
+  bosituasjon,
+  endreInformasjonPath,
+}) => {
+  const navigate = useNavigate();
+  const intl = useLokalIntlContext();
+
+  const samboerDetaljer =
+    bosituasjon.samboerDetaljer && VisLabelOgSvar(bosituasjon.samboerDetaljer);
+  const vordendeSamboerEktefelle =
+    bosituasjon.vordendeSamboerEktefelle &&
+    VisLabelOgSvar(bosituasjon.vordendeSamboerEktefelle);
+
+  const lagSamboerOverskrift = () => {
+    if (
+      bosituasjon.delerBoligMedAndreVoksne.svarid ===
+      ESøkerDelerBolig.tidligereSamboerFortsattRegistrertPåAdresse
+    ) {
+      return hentTekst('bosituasjon.tittel.omTidligereSamboer', intl);
+    } else if (
+      bosituasjon.delerBoligMedAndreVoksne.svarid ===
+      ESøkerDelerBolig.harEkteskapsliknendeForhold
+    ) {
+      return hentTekst('bosituasjon.tittel.omSamboer', intl);
+    }
+  };
+
+  return (
+    <StyledOppsummering>
+      <KomponentGruppe>{VisLabelOgSvar(bosituasjon)}</KomponentGruppe>
+      {samboerDetaljer && (
+        <KomponentGruppe>
+          <Ingress>{lagSamboerOverskrift()}</Ingress>
+          {samboerDetaljer}
+        </KomponentGruppe>
+      )}
+
+      {vordendeSamboerEktefelle && (
+        <KomponentGruppe>
+          <Ingress>
+            {hentTekst(
+              'bosituasjon.tittel.hvemSkalSøkerGifteEllerBliSamboerMed',
+              intl
+            )}
+          </Ingress>
+          {vordendeSamboerEktefelle}
+        </KomponentGruppe>
+      )}
+
+      <LenkeMedIkon
+        onClick={() =>
+          navigate(
+            { pathname: endreInformasjonPath },
+            { state: { kommerFraOppsummering: true } }
+          )
+        }
+        tekst_id="barnasbosted.knapp.endre"
+        ikon={endre}
+      />
+    </StyledOppsummering>
+  );
+};
+
+export default OppsummeringBosituasionenDin;

--- a/src/barnetilsyn/steg/7-oppsummering/OppsummeringOmDeg.tsx
+++ b/src/barnetilsyn/steg/7-oppsummering/OppsummeringOmDeg.tsx
@@ -1,0 +1,127 @@
+import { FC } from 'react';
+import {
+  VisLabelOgSvar,
+  visLabelOgVerdiForSpørsmålFelt,
+  visListeAvLabelOgSvar,
+} from '../../../utils/visning';
+import endre from '../../../assets/endre.svg';
+import LenkeMedIkon from '../../../components/knapper/LenkeMedIkon';
+import { hentTekst } from '../../../utils/søknad';
+import {
+  IMedlemskap,
+  IUtenlandsopphold,
+} from '../../../models/steg/omDeg/medlemskap';
+import { ISivilstatus } from '../../../models/steg/omDeg/sivilstatus';
+import { ISøker } from '../../../models/søknad/person';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import {
+  SeksjonSpacingTop,
+  StyledOppsummering,
+  StyledOppsummeringMedUndertitler,
+} from '../../../components/stegKomponenter/StyledOppsummering';
+import LocaleTekst from '../../../language/LocaleTekst';
+import { useNavigate } from 'react-router-dom';
+import { BodyShort, Ingress, Label } from '@navikt/ds-react';
+import { ISpørsmålBooleanFelt } from '../../../models/søknad/søknadsfelter';
+
+interface Props {
+  søker: ISøker;
+  søkerBorPåRegistrertAdresse?: ISpørsmålBooleanFelt;
+  harMeldtAdresseendring?: ISpørsmålBooleanFelt;
+  sivilstatus: ISivilstatus;
+  medlemskap: IMedlemskap;
+  endreInformasjonPath?: string;
+}
+
+const OppsummeringOmDeg: FC<Props> = ({
+  søker,
+  søkerBorPåRegistrertAdresse,
+  harMeldtAdresseendring,
+  sivilstatus,
+  medlemskap,
+  endreInformasjonPath,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const navigate = useNavigate();
+  const omDeg = søker;
+  const utenlandsopphold: IUtenlandsopphold[] | undefined =
+    medlemskap.perioderBoddIUtlandet;
+
+  const borDuPåDenneAdressen = visLabelOgVerdiForSpørsmålFelt(
+    søkerBorPåRegistrertAdresse,
+    intl
+  );
+
+  const harDuMeldtAdresseendring = visLabelOgVerdiForSpørsmålFelt(
+    harMeldtAdresseendring,
+    intl
+  );
+  const datoFlyttetFraHverandre = VisLabelOgSvar(sivilstatus);
+  const tidligereSamboer = VisLabelOgSvar(sivilstatus.tidligereSamboerDetaljer);
+  const medlemskapSpørsmål = VisLabelOgSvar(medlemskap);
+
+  const perioderUtland = visListeAvLabelOgSvar(
+    utenlandsopphold,
+    hentTekst('medlemskap.periodeBoddIUtlandet.utenlandsopphold', intl)
+  );
+
+  return (
+    <>
+      <KomponentGruppe>
+        <StyledOppsummering>
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              <LocaleTekst tekst="person.ident" />
+            </Label>
+            <BodyShort>{omDeg.fnr}</BodyShort>
+          </div>
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              <LocaleTekst tekst="person.statsborgerskap" />
+            </Label>
+            <BodyShort>{omDeg.statsborgerskap}</BodyShort>
+          </div>
+          <div className="spørsmål-og-svar">
+            <Label as="p">
+              <LocaleTekst tekst="person.adresse" />
+            </Label>
+            <BodyShort>{omDeg.adresse.adresse}</BodyShort>
+            <BodyShort>
+              {omDeg.adresse.postnummer} {omDeg.adresse.poststed}
+            </BodyShort>
+          </div>
+          {borDuPåDenneAdressen}
+          {harDuMeldtAdresseendring}
+          {tidligereSamboer && (
+            <div className="spørsmål-og-svar">
+              <Ingress>
+                {hentTekst('sivilstatus.tittel.samlivsbruddAndre', intl)}
+              </Ingress>
+              {tidligereSamboer}
+            </div>
+          )}
+          {datoFlyttetFraHverandre}
+          {medlemskapSpørsmål}
+        </StyledOppsummering>
+
+        <StyledOppsummeringMedUndertitler>
+          <SeksjonSpacingTop>{perioderUtland}</SeksjonSpacingTop>
+        </StyledOppsummeringMedUndertitler>
+      </KomponentGruppe>
+      <LenkeMedIkon
+        onClick={() =>
+          navigate(
+            { pathname: endreInformasjonPath },
+            { state: { kommerFraOppsummering: true } }
+          )
+        }
+        tekst_id="barnasbosted.knapp.endre"
+        ikon={endre}
+      />
+    </>
+  );
+};
+
+export default OppsummeringOmDeg;

--- a/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -2,8 +2,7 @@ import React, { useEffect } from 'react';
 import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 import { hentTekst, unikeDokumentasjonsbehov } from '../../../utils/søknad';
 import { useLocation } from 'react-router-dom';
-import { usePrevious } from '../../../utils/hooks';
-import LastOppVedlegg from '../../../søknad/steg/8-dokumentasjon/LastOppVedlegg';
+import { useMount, usePrevious } from '../../../utils/hooks';
 import SendSøknadKnapper from './SendBarnetilsynSøknad';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
 import Side, { ESide } from '../../../components/side/Side';
@@ -12,14 +11,14 @@ import { IVedlegg } from '../../../models/steg/vedlegg';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
-import { useMount } from '../../../utils/hooks';
 import { ISøknad } from '../../models/søknad';
 import { IDokumentasjon } from '../../../models/steg/dokumentasjon';
 import { erVedleggstidspunktGyldig } from '../../../utils/dato';
 import * as Sentry from '@sentry/browser';
 import { useDebouncedCallback } from 'use-debounce';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
-import { DokumentasjonBeskrivelse } from '../../../søknad/steg/8-dokumentasjon/DokumentasjonBeskrivelse';
+import { DokumentasjonBeskrivelse } from './DokumentasjonBeskrivelse';
+import LastOppVedlegg from './LastOppVedlegg';
 
 const Dokumentasjon: React.FC = () => {
   const intl = useLokalIntlContext();

--- a/src/barnetilsyn/steg/8-dokumentasjon/DokumentasjonBeskrivelse.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/DokumentasjonBeskrivelse.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { ReadMore } from '@navikt/ds-react';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import styled from 'styled-components';
+import { hentTekst } from '../../../utils/søknad';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import LocaleTekst from '../../../language/LocaleTekst';
+
+const ReadMoreMedPadding = styled(ReadMore)`
+  padding: 1rem 0;
+`;
+
+const SeksjonsGruppeMindrePadding = styled(SeksjonGruppe)`
+  padding-bottom: 50px;
+`;
+
+interface Props {
+  harDokumentasjonsbehov: boolean;
+}
+
+export const DokumentasjonBeskrivelse: React.FC<Props> = ({
+  harDokumentasjonsbehov,
+}) => {
+  const intl = useLokalIntlContext();
+  return (
+    <SeksjonsGruppeMindrePadding>
+      {harDokumentasjonsbehov ? (
+        <>
+          <LocaleTekst tekst={'dokumentasjon.beskrivelse'} />
+          <ReadMoreMedPadding
+            header={hentTekst('dokumentasjon.beskrivelseBilderHeader', intl)}
+          >
+            <LocaleTekst tekst={'dokumentasjon.beskrivelseBilderInnhold'} />
+          </ReadMoreMedPadding>
+          <LocaleTekst tekst={'dokumentasjon.beskrivelseSlutt'} />
+        </>
+      ) : (
+        <LocaleTekst
+          tekst={'dokumentasjon.ingenDokumentasjonsbehov.beskrivelse'}
+        />
+      )}
+    </SeksjonsGruppeMindrePadding>
+  );
+};

--- a/src/barnetilsyn/steg/8-dokumentasjon/GrøntDokumentIkon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/GrøntDokumentIkon.tsx
@@ -1,0 +1,61 @@
+export const GrøntDokumentIkon = () => {
+  return (
+    <svg
+      width="87"
+      height="87"
+      viewBox="0 0 87 87"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="43.5" cy="43.5" r="43.5" fill="#A8DBB1" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M22 25.6V69.1701C22 70.7329 23.2508 72 24.7943 72H62.2073C63.7492 72 65 70.7329 65 69.1701V18.8299C65 17.2671 63.7492 16 62.2073 16H32.3519L22 25.6Z"
+        fill="white"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M32.3519 16V22.6858C32.3519 24.2956 31.0204 25.6 29.3773 25.6H22L32.3519 16Z"
+        fill="#C9C9C9"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M29.963 36.8H57.0371V34.4H29.963V36.8Z"
+        fill="#6A6A6A"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M29.963 42.4H57.0371V40H29.963V42.4Z"
+        fill="#6A6A6A"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M29.963 48H57.0371V45.6H29.963V48Z"
+        fill="#6A6A6A"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M29.963 53.6H57.0371V51.2H29.963V53.6Z"
+        fill="#6A6A6A"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M29.963 59.2H57.0371V56.8H29.963V59.2Z"
+        fill="#6A6A6A"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M29.963 31.2H57.0371V28.8H29.963V31.2Z"
+        fill="#6A6A6A"
+      />
+    </svg>
+  );
+};

--- a/src/barnetilsyn/steg/8-dokumentasjon/LastOppVedlegg.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/LastOppVedlegg.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import Filopplaster from '../../../components/filopplaster/Filopplaster';
+import LocaleTekst from '../../../language/LocaleTekst';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import { hentTekst } from '../../../utils/søknad';
+import {
+  BarnetilsynDokumentasjon,
+  IDokumentasjon,
+} from '../../../models/steg/dokumentasjon';
+import { IVedlegg } from '../../../models/steg/vedlegg';
+import { EFiltyper } from '../../../helpers/filtyper';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { Checkbox, GuidePanel, Heading } from '@navikt/ds-react';
+import styled from 'styled-components';
+import { GrøntDokumentIkon } from './GrøntDokumentIkon';
+
+const StyledSeksjonGruppe = styled(SeksjonGruppe)`
+  padding-bottom: 40px;
+`;
+
+const StyledGuidePanel = styled(GuidePanel)`
+  .navds-guide {
+    border: none;
+  }
+`;
+
+interface Props {
+  dokumentasjon: IDokumentasjon;
+  oppdaterDokumentasjon: (
+    dokumentasjonsid: string,
+    opplastedeVedlegg: IVedlegg[] | undefined,
+    harSendtInnTidligere: boolean
+  ) => void;
+}
+
+const LastOppVedlegg: React.FC<Props> = ({
+  dokumentasjon,
+  oppdaterDokumentasjon,
+}) => {
+  const intl = useLokalIntlContext();
+
+  const settHarSendtInnTidligere = (huketAv: boolean) => {
+    const vedlegg = huketAv ? [] : dokumentasjon.opplastedeVedlegg;
+    oppdaterDokumentasjon(dokumentasjon.id, vedlegg, huketAv);
+  };
+
+  const hvisIkkeFakturaForBarnepass =
+    dokumentasjon.id !== BarnetilsynDokumentasjon.FAKTURA_BARNEPASSORDNING;
+
+  return (
+    <StyledSeksjonGruppe>
+      <StyledGuidePanel illustration={<GrøntDokumentIkon />} poster>
+        <FeltGruppe>
+          <Heading size="small" level="3" style={{ justifyContent: 'left' }}>
+            <LocaleTekst tekst={dokumentasjon.tittel} />
+          </Heading>
+        </FeltGruppe>
+        {dokumentasjon.beskrivelse && (
+          <FeltGruppe>
+            <LocaleTekst tekst={dokumentasjon.beskrivelse} />
+          </FeltGruppe>
+        )}
+        {hvisIkkeFakturaForBarnepass && (
+          <FeltGruppe>
+            <Checkbox
+              checked={dokumentasjon.harSendtInn}
+              onChange={(e) => settHarSendtInnTidligere(e.target.checked)}
+            >
+              {hentTekst('dokumentasjon.checkbox.sendtTidligere', intl)}
+            </Checkbox>
+          </FeltGruppe>
+        )}
+        {!dokumentasjon.harSendtInn && (
+          <Filopplaster
+            oppdaterDokumentasjon={oppdaterDokumentasjon}
+            dokumentasjon={dokumentasjon}
+            maxFilstørrelse={1024 * 1024 * 10}
+            tillatteFiltyper={[
+              EFiltyper.PNG,
+              EFiltyper.PDF,
+              EFiltyper.JPG,
+              EFiltyper.JPEG,
+            ]}
+          />
+        )}
+      </StyledGuidePanel>
+    </StyledSeksjonGruppe>
+  );
+};
+
+export default LastOppVedlegg;

--- a/src/barnetilsyn/steg/9-kvittering/DineSaker.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/DineSaker.tsx
@@ -1,0 +1,24 @@
+import { FC } from 'react';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import LocaleTekst from '../../../language/LocaleTekst';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { BodyShort } from '@navikt/ds-react';
+
+const DineSaker: FC = () => {
+  return (
+    <SeksjonGruppe>
+      <KomponentGruppe>
+        <BodyShort>
+          <LocaleTekst tekst={'kvittering.tekst.altViTrenger'} />
+        </BodyShort>
+      </KomponentGruppe>
+      <KomponentGruppe>
+        <BodyShort>
+          <LocaleTekst tekst={'kvittering.tekst.dineSaker'} />
+        </BodyShort>
+      </KomponentGruppe>
+    </SeksjonGruppe>
+  );
+};
+
+export default DineSaker;

--- a/src/barnetilsyn/steg/9-kvittering/ErklæringSamlivsbrudd.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/ErklæringSamlivsbrudd.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import download from '../../../assets/download.svg';
+import styled from 'styled-components';
+import { StyledUndertittel } from '../../../components/gruppe/Spacing';
+import LocaleTekst from '../../../language/LocaleTekst';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { hentFilePath } from '../../../utils/språk';
+import { useSpråkContext } from '../../../context/SpråkContext';
+import { BodyShort, Label, Link } from '@navikt/ds-react';
+import { useHentFilInformasjon } from '../../../utils/hooks';
+
+const StyledLenke = styled.div`
+  margin-top: 1rem;
+
+  img {
+    margin-right: 0.5rem;
+    display: inline;
+  }
+
+  p {
+    display: inline;
+  }
+`;
+
+const ErklæringSamlivsbrudd: FC = () => {
+  const intl = useLokalIntlContext();
+  const [locale] = useSpråkContext();
+
+  const hentÆrklæringBasertPåSpråk = (): string => {
+    return hentFilePath(locale, {
+      nb: '/familie/alene-med-barn/soknad/filer/Erklaering_om_samlivsbrudd.pdf',
+      en: '/familie/alene-med-barn/soknad/filer/Declaration_on_end_of_relationship_EN.pdf',
+      nn: '/familie/alene-med-barn/soknad/filer/Erklaering_om_samlivsbrot_NN.pdf',
+    });
+  };
+
+  const { filInformasjon } = useHentFilInformasjon(
+    hentÆrklæringBasertPåSpråk()
+  );
+
+  return (
+    <SeksjonGruppe>
+      <StyledUndertittel size="small">
+        <LocaleTekst tekst={'kvittering.tittel.samlivsbrudd'} />
+      </StyledUndertittel>
+      <BodyShort>
+        <LocaleTekst tekst={'kvittering.beskrivelse.samlivsbrudd'} />
+      </BodyShort>
+
+      <StyledLenke>
+        <Link href={hentÆrklæringBasertPåSpråk()} download>
+          <img alt="Nedlastingsikon" src={download} />
+          <Label as="p">
+            {intl.formatMessage({ id: 'kvittering.knapp.samlivsbrudd' })}
+            {filInformasjon}
+          </Label>
+        </Link>
+      </StyledLenke>
+    </SeksjonGruppe>
+  );
+};
+
+export default ErklæringSamlivsbrudd;

--- a/src/barnetilsyn/steg/9-kvittering/EttersendDokumentasjon.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/EttersendDokumentasjon.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import { IDokumentasjon } from '../../../models/steg/dokumentasjon';
+import { Stønadstype } from '../../../models/søknad/stønadstyper';
+import LocaleTekst from '../../../language/LocaleTekst';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import FeltGruppe from '../../../components/gruppe/FeltGruppe';
+import { Heading, BodyShort } from '@navikt/ds-react';
+
+interface Props {
+  stønadstype: Stønadstype;
+  dokumentasjonsbehov: IDokumentasjon[];
+}
+
+const EttersendDokumentasjon: FC<Props> = ({
+  stønadstype,
+  dokumentasjonsbehov,
+}) => {
+  return dokumentasjonsbehov.length > 0 ? (
+    <KomponentGruppe>
+      <FeltGruppe>
+        <Heading size="small" level="3">
+          <LocaleTekst tekst={'dokumentasjon.ettersend.tittel'} />
+        </Heading>
+      </FeltGruppe>
+      <FeltGruppe>
+        <BodyShort>
+          <LocaleTekst tekst={`dokumentasjon.ettersend.tekst.${stønadstype}`} />
+        </BodyShort>
+      </FeltGruppe>
+    </KomponentGruppe>
+  ) : null;
+};
+export default EttersendDokumentasjon;

--- a/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/Kvittering.tsx
@@ -4,16 +4,11 @@ import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
 import { formatDateHour } from '../../../utils/dato';
 import { hentTekst, oppdaterBarnMedLabel } from '../../../utils/søknad';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
-import SykSøker from '../../../søknad/steg/9-kvittering/SykSøker';
-import DineSaker from '../../../søknad/steg/9-kvittering/DineSaker';
 import { ErIArbeid } from '../../../models/steg/aktivitet/aktivitet';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
-import ErklæringSamlivsbrudd from '../../../søknad/steg/9-kvittering/ErklæringSamlivsbrudd';
 import { EBegrunnelse } from '../../../models/steg/omDeg/sivilstatus';
 import Side, { ESide } from '../../../components/side/Side';
 import { RoutesBarnetilsyn } from '../../routing/routesBarnetilsyn';
-import RegistrerBarnIFolkeregister from '../../../søknad/steg/9-kvittering/RegistrerBarnIFolkeregister';
-import EttersendDokumentasjon from '../../../søknad/steg/9-kvittering/EttersendDokumentasjon';
 import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { usePersonContext } from '../../../context/PersonContext';
 import { hentFilePath } from '../../../utils/språk';
@@ -22,6 +17,11 @@ import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
 import { IBarn } from '../../../models/steg/barn';
 import { Alert } from '@navikt/ds-react';
+import DineSaker from './DineSaker';
+import EttersendDokumentasjon from './EttersendDokumentasjon';
+import SykSøker from './SykSøker';
+import ErklæringSamlivsbrudd from './ErklæringSamlivsbrudd';
+import RegistrerBarnIFolkeregister from './RegistrerBarnIFolkeregister';
 
 const Kvittering: React.FC = () => {
   const intl = useLokalIntlContext();

--- a/src/barnetilsyn/steg/9-kvittering/RegistrerBarnIFolkeregister.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/RegistrerBarnIFolkeregister.tsx
@@ -1,0 +1,60 @@
+import { FC } from 'react';
+import { ESkalBarnetBoHosSøker } from '../../../models/steg/barnasbosted';
+import { IBarn } from '../../../models/steg/barn';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { hentTekst } from '../../../utils/søknad';
+import { flereBarnsNavn } from '../../../utils/barn';
+import { hentBeskjedMedNavn } from '../../../utils/språk';
+import LocaleTekst from '../../../language/LocaleTekst';
+import KomponentGruppe from '../../../components/gruppe/KomponentGruppe';
+import { StyledUndertittel } from '../../../components/gruppe/Spacing';
+import { BodyShort } from '@navikt/ds-react';
+
+interface Props {
+  barna: IBarn[];
+}
+
+const RegistrerBarnIFolkeregister: FC<Props> = ({ barna }) => {
+  const intl = useLokalIntlContext();
+
+  const barnSomSkalRegistreresIFolkeregister = barna.filter((barn) => {
+    return (
+      barn?.forelder?.skalBarnetBoHosSøker?.svarid === ESkalBarnetBoHosSøker.ja
+    );
+  });
+
+  if (barnSomSkalRegistreresIFolkeregister.length === 0) {
+    return null;
+  }
+
+  const barnasNavn = flereBarnsNavn(barnSomSkalRegistreresIFolkeregister, intl);
+  const tekst = hentBeskjedMedNavn(
+    barnasNavn,
+    hentTekst('barnasbosted.skalBliFolkeregistrert.tekst', intl)
+  );
+  const undertittelMedNavn = hentBeskjedMedNavn(
+    barnasNavn,
+    hentTekst('barnasbosted.skalBliFolkeregistrert.tekst', intl)
+  );
+
+  return (
+    <SeksjonGruppe>
+      <StyledUndertittel size={'small'}>{undertittelMedNavn}</StyledUndertittel>
+      <BodyShort>{tekst}</BodyShort>
+      <KomponentGruppe>
+        <a
+          target={'_blank'}
+          rel={'noreferrer noopener'}
+          className={'knapp knapp--standard kvittering'}
+          href={
+            'https://www.skatteetaten.no/person/folkeregister/flytte/i-norge/'
+          }
+        >
+          <LocaleTekst tekst={'barnasbosted.skalBliFolkeregistrert.knapp'} />
+        </a>
+      </KomponentGruppe>
+    </SeksjonGruppe>
+  );
+};
+export default RegistrerBarnIFolkeregister;

--- a/src/barnetilsyn/steg/9-kvittering/SykSøker.tsx
+++ b/src/barnetilsyn/steg/9-kvittering/SykSøker.tsx
@@ -1,0 +1,49 @@
+import { FC } from 'react';
+import SeksjonGruppe from '../../../components/gruppe/SeksjonGruppe';
+import download from '../../../assets/download.svg';
+import { StyledUndertittel } from '../../../components/gruppe/Spacing';
+import styled from 'styled-components';
+import LocaleTekst from '../../../language/LocaleTekst';
+import { useLokalIntlContext } from '../../../context/LokalIntlContext';
+import { BodyShort, Label, Link } from '@navikt/ds-react';
+import { useHentFilInformasjon } from '../../../utils/hooks';
+
+const StyledLenke = styled.div`
+  margin-top: 1rem;
+
+  img {
+    margin-right: 0.5rem;
+    display: inline;
+  }
+
+  p {
+    display: inline;
+  }
+`;
+
+const SykSøker: FC<{ filPath: string }> = ({ filPath }) => {
+  const intl = useLokalIntlContext();
+  const { filInformasjon } = useHentFilInformasjon(filPath);
+  return (
+    <SeksjonGruppe>
+      <StyledUndertittel size="small">
+        <LocaleTekst tekst={'kvittering.tittel.huskeliste.erSyk'} />
+      </StyledUndertittel>
+
+      <BodyShort>
+        <LocaleTekst tekst={'kvittering.beskrivelse.huskeliste.erSyk'} />
+      </BodyShort>
+      <StyledLenke>
+        <Link href={filPath} download>
+          <img alt="Nedlastingsikon" src={download} />
+          <Label as="p">
+            {intl.formatMessage({ id: 'kvittering.knapp.huskeliste.erSyk' })}
+            {filInformasjon}
+          </Label>
+        </Link>
+      </StyledLenke>
+    </SeksjonGruppe>
+  );
+};
+
+export default SykSøker;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Kopierer ut komponenter fra den generelle "søknad" mappen over i barnetilsyn. De originale ligger der fortsatt, da overgangsstønad og skolepenger fortsatt bruker de.

Dette er en del av det horisontalet skillet mellom søknader vi har snakket om.

Det er sikkert mye som kan refaktureres og fjernes, men dette gjøres i senere PRer.

OBS: gjerne ta en ekstra titt på commit nr. 2 ([Fjernet unødvendig prop-drilling av medlemskap](https://github.com/navikt/familie-ef-soknad-frontend/pull/1888/commits/821ed1eeeae3b4e28fdb13ec98ac44a0e912541f)) da den tar for seg noe annet enn ren flytting.