### PR TITLE
renamer interface for søknad til barnetilsyn for bedre lesbarhet

### DIFF
--- a/src/barnetilsyn/BarnetilsynContext.tsx
+++ b/src/barnetilsyn/BarnetilsynContext.tsx
@@ -3,13 +3,13 @@ import createUseContext from 'constate';
 import tomPerson from '../mock/initialState.json';
 import { EBosituasjon } from '../models/steg/bosituasjon';
 import { ISpørsmål, ISvar } from '../models/felles/spørsmålogsvar';
-import { ForrigeSøknad, ISøknad } from './models/søknad';
+import { ForrigeSøknad, SøknadBarnetilsyn } from './models/søknad';
 import {
   hentDokumentasjonTilFlersvarSpørsmål,
   oppdaterDokumentasjonTilEtSvarSpørsmål,
   oppdaterDokumentasjonTilEtSvarSpørsmålForBarn,
 } from '../helpers/steg/dokumentasjon';
-import { IMellomlagretBarnetilsynSøknad } from './models/mellomlagretSøknad';
+import { MellomlagretSøknadBarnetilsyn } from './models/mellomlagretSøknad';
 import Environment from '../Environment';
 import { EArbeidssituasjon } from '../models/steg/aktivitet/aktivitet';
 import {
@@ -40,7 +40,7 @@ import {
 } from '../helpers/steg/forelder';
 import { stringHarVerdiOgErIkkeTom } from '../utils/typer';
 
-const initialState = (intl: LokalIntlShape): ISøknad => {
+const initialState = (intl: LokalIntlShape): SøknadBarnetilsyn => {
   return {
     person: tomPerson,
     sivilstatus: {},
@@ -76,9 +76,11 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
     const intl = useLokalIntlContext();
     BarnetilsynSøknadProvider.displayName = 'BARNETILSYN_PROVIDER';
     const [locale, setLocale] = useSpråkContext();
-    const [søknad, settSøknad] = useState<ISøknad>(initialState(intl));
+    const [søknad, settSøknad] = useState<SøknadBarnetilsyn>(
+      initialState(intl)
+    );
     const [mellomlagretBarnetilsyn, settMellomlagretBarnetilsyn] =
-      useState<IMellomlagretBarnetilsynSøknad>();
+      useState<MellomlagretSøknadBarnetilsyn>();
 
     useEffect(() => {
       if (
@@ -90,9 +92,9 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
     }, [mellomlagretBarnetilsyn, locale, setLocale]);
 
     const hentMellomlagretBarnetilsyn = (): Promise<void> => {
-      return hentMellomlagretSøknadFraDokument<IMellomlagretBarnetilsynSøknad>(
+      return hentMellomlagretSøknadFraDokument<MellomlagretSøknadBarnetilsyn>(
         MellomlagredeStønadstyper.barnetilsyn
-      ).then((mellomlagretVersjon?: IMellomlagretBarnetilsynSøknad) => {
+      ).then((mellomlagretVersjon?: MellomlagretSøknadBarnetilsyn) => {
         if (mellomlagretVersjon) {
           settMellomlagretBarnetilsyn(mellomlagretVersjon);
         }
@@ -170,7 +172,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
     };
 
     const erForelderEllerKopiertForelderFraFolkeRegister = (
-      forrigeSøknad: ISøknad,
+      forrigeSøknad: SøknadBarnetilsyn,
       forelder: IForelder | undefined
     ) => {
       return (
@@ -188,7 +190,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
     const oppdaterBarnForelderIdentOgNavn = (
       forelder: IForelder | undefined,
       medforelder: IMedforelderFelt | undefined,
-      prevSøknad: ISøknad
+      prevSøknad: SøknadBarnetilsyn
     ): IForelder => {
       const erFraFolkeRegister = erForelderEllerKopiertForelderFraFolkeRegister(
         prevSøknad,
@@ -336,7 +338,7 @@ const [BarnetilsynSøknadProvider, useBarnetilsynSøknad] = createUseContext(
       };
 
     const finnNyeBarnSidenForrigeSøknad = (
-      prevSøknad: ISøknad,
+      prevSøknad: SøknadBarnetilsyn,
       forrigeSøknad: ForrigeSøknad
     ): IBarn[] => {
       return prevSøknad.person.barn.filter(

--- a/src/barnetilsyn/models/mellomlagretSøknad.ts
+++ b/src/barnetilsyn/models/mellomlagretSøknad.ts
@@ -1,7 +1,7 @@
-import { ISøknad } from './søknad';
+import { SøknadBarnetilsyn } from './søknad';
 
-export interface IMellomlagretBarnetilsynSøknad {
-  søknad: ISøknad;
+export interface MellomlagretSøknadBarnetilsyn {
+  søknad: SøknadBarnetilsyn;
   modellVersjon: number;
   gjeldendeSteg: string;
   locale: string;

--- a/src/barnetilsyn/models/søknad.ts
+++ b/src/barnetilsyn/models/søknad.ts
@@ -10,7 +10,7 @@ import { IAktivitet } from '../../models/steg/aktivitet/aktivitet';
 import { IPerson, IPersonTilGjenbruk } from '../../models/søknad/person';
 import { IAdresseopplysninger } from '../../models/steg/adresseopplysninger';
 
-export interface ISøknad {
+export interface SøknadBarnetilsyn {
   innsendingsdato?: Date;
   person: IPerson;
   søkerBorPåRegistrertAdresse?: ISpørsmålBooleanFelt;

--- a/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
+++ b/src/barnetilsyn/steg/1-omdeg/OmDeg.tsx
@@ -20,7 +20,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import Show from '../../../utils/showIf';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
-import { ISøknad } from '../../models/søknad';
+import { SøknadBarnetilsyn } from '../../models/søknad';
 import { kommerFraOppsummeringen } from '../../../utils/locationState';
 import { useLokalIntlContext } from '../../../context/LokalIntlContext';
 
@@ -42,7 +42,7 @@ const OmDeg: FC = () => {
   const { søker } = søknad.person;
 
   const settMedlemskap = (medlemskap: IMedlemskap) => {
-    settSøknad((prevSoknad: ISøknad) => {
+    settSøknad((prevSoknad: SøknadBarnetilsyn) => {
       return {
         ...prevSoknad,
         medlemskap:
@@ -56,7 +56,7 @@ const OmDeg: FC = () => {
   const settSøkerBorPåRegistrertAdresse = (
     søkerBorPåRegistrertAdresse: ISpørsmålBooleanFelt
   ) => {
-    settSøknad((prevSoknad: ISøknad) => {
+    settSøknad((prevSoknad: SøknadBarnetilsyn) => {
       return {
         ...prevSoknad,
         adresseopplysninger: undefined,
@@ -68,7 +68,7 @@ const OmDeg: FC = () => {
   const settHarMeldtAdresseendring = (
     harMeldtAdresseendring: ISpørsmålBooleanFelt
   ) => {
-    settSøknad((prevSøknad: ISøknad) => ({
+    settSøknad((prevSøknad: SøknadBarnetilsyn) => ({
       ...prevSøknad,
       adresseopplysninger: {
         ...prevSøknad.adresseopplysninger,
@@ -78,7 +78,7 @@ const OmDeg: FC = () => {
   };
 
   const settSivilstatus = (sivilstatus: ISivilstatus) => {
-    settSøknad((prevSoknad: ISøknad) => {
+    settSøknad((prevSoknad: SøknadBarnetilsyn) => {
       return {
         ...prevSoknad,
         sivilstatus: sivilstatus,

--- a/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
+++ b/src/barnetilsyn/steg/2-bosituasjon/Bosituasjon.tsx
@@ -12,7 +12,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
-import { ISøknad } from '../../models/søknad';
+import { SøknadBarnetilsyn } from '../../models/søknad';
 import { kommerFraOppsummeringen } from '../../../utils/locationState';
 
 const Bosituasjon: FC = () => {
@@ -33,7 +33,7 @@ const Bosituasjon: FC = () => {
     : ESide.visTilbakeTilOppsummeringKnapp;
 
   const settBosituasjon = (bosituasjon: IBosituasjon) => {
-    settSøknad((prevSoknad: ISøknad) => {
+    settSøknad((prevSoknad: SøknadBarnetilsyn) => {
       return {
         ...prevSoknad,
         bosituasjon: bosituasjon,

--- a/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
+++ b/src/barnetilsyn/steg/6-barnepass/Barnepass.tsx
@@ -28,7 +28,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
 import { IBarn } from '../../../models/steg/barn';
-import { ISøknad } from '../../models/søknad';
+import { SøknadBarnetilsyn } from '../../models/søknad';
 import {
   dagensDato,
   datoTilStreng,
@@ -86,7 +86,7 @@ const Barnepass: FC = () => {
       }
       return barn;
     });
-    settSøknad((prevSøknad: ISøknad) => {
+    settSøknad((prevSøknad: SøknadBarnetilsyn) => {
       return {
         ...prevSøknad,
         person: { ...prevSøknad.person, barn: endretBarn },
@@ -96,7 +96,7 @@ const Barnepass: FC = () => {
 
   const settSøknadsdato = (dato: Date | null) => {
     dato !== null &&
-      settSøknad((prevSøknad: ISøknad) => {
+      settSøknad((prevSøknad: SøknadBarnetilsyn) => {
         return {
           ...prevSøknad,
           søknadsdato: {
@@ -108,7 +108,7 @@ const Barnepass: FC = () => {
   };
 
   const settSøkerFraBestemtMåned = (spørsmål: ISpørsmål, svar: ISvar) => {
-    settSøknad((prevSoknad: ISøknad) => {
+    settSøknad((prevSoknad: SøknadBarnetilsyn) => {
       if (
         svar.id === ESøkerFraBestemtMåned.neiNavKanVurdere &&
         søknadsdato?.verdi

--- a/src/barnetilsyn/steg/6-barnepass/hjelper.ts
+++ b/src/barnetilsyn/steg/6-barnepass/hjelper.ts
@@ -9,7 +9,7 @@ import {
   ETypeBarnepassOrdning,
   IBarnepassOrdning,
 } from '../../models/barnepass';
-import { ISøknad } from '../../models/søknad';
+import { SøknadBarnetilsyn } from '../../models/søknad';
 import { ESøkerFraBestemtMåned } from '../../../models/steg/dinsituasjon/meromsituasjon';
 import { harValgtSvar } from '../../../utils/spørsmålogsvar';
 import { erStrengGyldigTall } from '../../../utils/autentiseringogvalidering/feltvalidering';
@@ -58,7 +58,7 @@ export const erBarnepassOrdningerUtfylt = (
 
 export const erBarnepassStegFerdigUtfylt = (
   barnSomSkalHaBarnepass: IBarn[],
-  søknad: ISøknad
+  søknad: SøknadBarnetilsyn
 ): boolean => {
   const { søkerFraBestemtMåned, søknadsdato } = søknad;
   const erSpørsmålSøkerFraBestemtMånedBesvart =

--- a/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/Dokumentasjon.tsx
@@ -13,7 +13,7 @@ import { Stønadstype } from '../../../models/søknad/stønadstyper';
 
 import { logSidevisningBarnetilsyn } from '../../../utils/amplitude';
 import { useMount } from '../../../utils/hooks';
-import { ISøknad } from '../../models/søknad';
+import { SøknadBarnetilsyn } from '../../models/søknad';
 import { IDokumentasjon } from '../../../models/steg/dokumentasjon';
 import { erVedleggstidspunktGyldig } from '../../../utils/dato';
 import * as Sentry from '@sentry/browser';
@@ -36,7 +36,7 @@ const Dokumentasjon: React.FC = () => {
     opplastedeVedlegg: IVedlegg[] | undefined,
     harSendtInnTidligere: boolean
   ) => {
-    settSøknad((prevSoknad: ISøknad) => {
+    settSøknad((prevSoknad: SøknadBarnetilsyn) => {
       const dokumentasjonMedVedlegg = prevSoknad.dokumentasjonsbehov.map(
         (dok) => {
           return dok.id === dokumentasjonsid

--- a/src/barnetilsyn/steg/8-dokumentasjon/SendBarnetilsynSøknad.tsx
+++ b/src/barnetilsyn/steg/8-dokumentasjon/SendBarnetilsynSøknad.tsx
@@ -12,7 +12,7 @@ import {
   sendInnBarnetilsynSøknad,
 } from '../../../innsending/api';
 import { useBarnetilsynSøknad } from '../../BarnetilsynContext';
-import { ISøknad } from '../../models/søknad';
+import { SøknadBarnetilsyn } from '../../models/søknad';
 import { IBarn } from '../../../models/steg/barn';
 import {
   hentForrigeRoute,
@@ -42,7 +42,7 @@ interface Innsending {
   venter: boolean;
 }
 
-const validerSøkerBosattINorgeSisteFemÅr = (søknad: ISøknad) => {
+const validerSøkerBosattINorgeSisteFemÅr = (søknad: SøknadBarnetilsyn) => {
   return søknad.medlemskap.søkerBosattINorgeSisteTreÅr;
 };
 
@@ -66,7 +66,7 @@ const SendSøknadKnapper: FC = () => {
     return barneliste.filter((barn) => barn.skalHaBarnepass?.verdi === true);
   };
 
-  const sendInnSøknad = async (søknadMedFiltrerteBarn: ISøknad) => {
+  const sendInnSøknad = async (søknadMedFiltrerteBarn: SøknadBarnetilsyn) => {
     try {
       const kvittering = await sendInnBarnetilsynSøknad(søknadMedFiltrerteBarn);
 
@@ -93,7 +93,7 @@ const SendSøknadKnapper: FC = () => {
     }
   };
 
-  const sendSøknad = (søknad: ISøknad) => {
+  const sendSøknad = (søknad: SøknadBarnetilsyn) => {
     const barnMedEntenIdentEllerFødselsdato = filtrerBarnSomSkalHaBarnepass(
       mapBarnTilEntenIdentEllerFødselsdato(søknad.person.barn)
     );
@@ -106,7 +106,7 @@ const SendSøknadKnapper: FC = () => {
       unikeDokumentasjonsbehov
     );
     logDokumetasjonsbehov(dokumentasjonsbehov, ESkjemanavn.Barnetilsyn);
-    const søknadMedFiltrerteBarn: ISøknad = {
+    const søknadMedFiltrerteBarn: SøknadBarnetilsyn = {
       ...søknad,
       person: { ...søknad.person, barn: barnMedOppdaterteLabels },
       dokumentasjonsbehov: dokumentasjonsbehov,

--- a/src/helpers/steg/omdeg.ts
+++ b/src/helpers/steg/omdeg.ts
@@ -14,7 +14,7 @@ import {
   erSøkerUGiftSkiltSeparertEllerEnke,
 } from '../../utils/sivilstatus';
 import { ISøknad } from '../../models/søknad/søknad';
-import { ISøknad as ISøknadBT } from '../../barnetilsyn/models/søknad';
+import { SøknadBarnetilsyn } from '../../barnetilsyn/models/søknad';
 import { ISøknad as ISøknadSK } from '../../skolepenger/models/søknad';
 import { stringErNullEllerTom } from '../../utils/typer';
 
@@ -195,7 +195,7 @@ export const erSivilstandSpørsmålBesvart = (
 };
 
 export const søkerBorPåRegistrertAdresseEllerHarMeldtAdresseendring = (
-  søknad: ISøknad | ISøknadBT | ISøknadSK
+  søknad: ISøknad | SøknadBarnetilsyn | ISøknadSK
 ) => {
   return (
     søknad.person.søker?.erStrengtFortrolig ||
@@ -205,7 +205,7 @@ export const søkerBorPåRegistrertAdresseEllerHarMeldtAdresseendring = (
 };
 
 export const validerSøkerBosattINorgeSisteFemÅr = (
-  søknad: ISøknad | ISøknadBT | ISøknadSK
+  søknad: ISøknad | SøknadBarnetilsyn | ISøknadSK
 ) => {
   return søknad.medlemskap.søkerBosattINorgeSisteTreÅr;
 };

--- a/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnasBostedInnhold.tsx
@@ -17,7 +17,7 @@ import {
   ISøknad as SøknadOvergangsstønad,
   SettDokumentasjonsbehovBarn,
 } from '../../../models/søknad/søknad';
-import { ISøknad as SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
+import { SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
 import { ISøknad as SøknadSkolepenger } from '../../../skolepenger/models/søknad';
 
 const scrollTilRef = (ref: RefObject<HTMLDivElement | null>) => {

--- a/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
+++ b/src/søknad/steg/4-barnasbosted/BarnetsBostedEndre.tsx
@@ -38,7 +38,7 @@ import {
   skalAnnenForelderRedigeres,
 } from '../../../helpers/steg/barnetsBostedEndre';
 import { stringHarVerdiOgErIkkeTom } from '../../../utils/typer';
-import { ISøknad as SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
+import { SøknadBarnetilsyn } from '../../../barnetilsyn/models/søknad';
 import { ISøknad as SøknadSkolepenger } from '../../../skolepenger/models/søknad';
 
 const AlertMedTopMargin = styled(Alert)`

--- a/src/utils/søknad.ts
+++ b/src/utils/søknad.ts
@@ -11,10 +11,7 @@ import {
 } from '../helpers/labels';
 import { IBarn } from '../models/steg/barn';
 import { LokalIntlShape } from '../language/typer';
-import {
-  ForrigeSøknad,
-  ISøknad as SøknadBarnetilsyn,
-} from '../barnetilsyn/models/søknad';
+import { ForrigeSøknad, SøknadBarnetilsyn } from '../barnetilsyn/models/søknad';
 import { PersonData } from '../models/søknad/person';
 import { ISøknad as SøknadOvergangsstønad } from '../models/søknad/søknad';
 import { ISøknad as SøknadSkolepenger } from '../skolepenger/models/søknad';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- renamer `ISøknad` til `SøknadBarnetilsyn` 
- renamer `IMellomlagretBarnetilsynSøknad` til `MellomlagretSøknadBarnetilsyn`

For bedre lesbarhet