### PR TITLE
Fikser alert beskrivelse for dokumentasjonsbehov for mål med utdanning

### DIFF
--- a/src/language/tekster_en.ts
+++ b/src/language/tekster_en.ts
@@ -525,9 +525,9 @@ export default {
   'utdanning.spm.mål': 'What is your goal for taking this education?',
   'utdanning.alert-tittel.mål':
     'You must provide documentation of the education you are taking or are going to take',
-  'utdanning.alert-beskrivelse.mål.skolepenger':
+  'utdanning.alert-beskrivelse.mål.SKOLEPENGER':
     'The documentation must indicate:<ul><li>the name of the place of study</li><li>the name of the course or education</li><li>how much you are going to study</li><li>the period in which you are going to study</li></ul><br/>The documentation must clearly show who it concerns.',
-  'utdanning.alert-beskrivelse.mål.overgangsstønad':
+  'utdanning.alert-beskrivelse.mål.OVERGANGSSTØNAD':
     'The documentation must indicate:<ul><li>the name of the place of study</li><li>the name of the course or education</li><li>how much you are going to study</li><li>the period in which you are going to study</li></ul><br/>The documentation must clearly show who it concerns. If you are already receiving transitional benefit and are applying for an extension of the benefit period because you have been offered a place on a course of education, the documentation must also show the date on which you accepted the offer.',
   'utdanning.label.utgifter': 'Expenses for school fees',
   'utdanning.label.utgifter.dokumentasjon':

--- a/src/language/tekster_nb.ts
+++ b/src/language/tekster_nb.ts
@@ -511,9 +511,9 @@ export default {
   'utdanning.spm.mål': 'Hva er målet med utdanningen?',
   'utdanning.alert-tittel.mål':
     'Du må legge ved dokumentasjon på utdanningen du tar eller skal ta',
-  'utdanning.alert-beskrivelse.mål.skolepenger':
+  'utdanning.alert-beskrivelse.mål.SKOLEPENGER':
     'Dokumentasjonen må vise: <ul><li>navn på studiested</li><li>navn på studie</li><li>hvor mye du skal studere</li><li>perioden du skal studere</li></ul><br/>Dokumentasjonen må vise tydelig hvem det gjelder.',
-  'utdanning.alert-beskrivelse.mål.overgangsstønad':
+  'utdanning.alert-beskrivelse.mål.OVERGANGSSTØNAD':
     'Dokumentasjonen må vise: <ul><li>navn på studiested</li><li>navn på studie</li><li>hvor mye du skal studere</li><li>perioden du skal studere</li></ul><br/>Dokumentasjonen må vise tydelig hvem det gjelder. <br/>Får du allerede overgangsstønad og søker om å forlenge stønadsperioden fordi du har fått tilbud om studieplass? Da må dokumentasjonen også vise datoen du takket ja til tilbudet.',
   'utdanning.label.utgifter': 'Utgifter til skolepenger',
   'utdanning.label.utgifter.dokumentasjon':

--- a/src/language/tekster_nn.ts
+++ b/src/language/tekster_nn.ts
@@ -681,7 +681,7 @@ export default {
   'utdanning.spm.mål': 'What is your goal for taking this education?',
   'utdanning.alert-tittel.mål':
     'You must provide documentation of the education you are taking or are going to take',
-  'utdanning.alert-beskrivelse.mål.skolepenger':
+  'utdanning.alert-beskrivelse.mål.SKOLEPENGER':
     'The documentation must indicate:<ul>' +
     '<li>the name of the place of study</li>' +
     '<li>the name of the course or education</li>' +
@@ -689,7 +689,7 @@ export default {
     '<li>the period in which you are going to study</li>' +
     '</ul><br/><br/>' +
     'The documentation must clearly show who it concerns. ',
-  'utdanning.alert-beskrivelse.mål.overgangsstønad':
+  'utdanning.alert-beskrivelse.mål.OVERGANGSTTØNAD':
     'The documentation must indicate:<ul>' +
     '<li>the name of the place of study</li>' +
     '<li>the name of the course or education</li>' +


### PR DESCRIPTION
# Fikser alert beskrivelse for dokumentasjonsbehov for mål med utdanning

### Hvorfor er denne endringen nødvendig? ✨ 

| Etter | Før |
|-----|-------|
| ![før](https://github.com/user-attachments/assets/ee1e9639-5f3a-4a90-8bae-975fb0387549) | ![etter](https://github.com/user-attachments/assets/f579ed2a-f4bc-4046-9919-b005ba5d1ed2) |

Grunnet en refaktorering av overgangstønad type en liten stund tilbake har verdien for typen endret seg fra lowercase til uppercase. Dette ødelegger henting av alert tekst. Dette er nå fikses og burde vise riktig beskrivelse. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25412).

### Verdt å nevne

Har bare testet i pre-prod med skolepenger.


