### PR TITLE
Personopplysninger - fjern komponent og feltgruppe, legge til visning kondisjonal for spørsmål.

### DIFF
--- a/src/søknader/felles/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknader/felles/steg/1-omdeg/OmDeg.tsx
@@ -6,7 +6,7 @@ import {
   erÅrsakEnsligBesvart,
 } from '../../../../helpers/steg/omdeg';
 import Medlemskap from '../../../felles/steg/1-omdeg/medlemskap/Medlemskap';
-import { Personopplysninger } from '../../../felles/steg/1-omdeg/personopplysninger/Personopplysninger';
+import { Personopplysninger } from './personopplysninger/Personopplysninger';
 import Sivilstatus from '../../../felles/steg/1-omdeg/sivilstatus/Sivilstatus';
 import { Side, NavigasjonState } from '../../../../components/side/Side';
 import { kommerFraOppsummeringen } from '../../../../utils/locationState';

--- a/src/søknader/felles/steg/1-omdeg/OmDeg.tsx
+++ b/src/søknader/felles/steg/1-omdeg/OmDeg.tsx
@@ -6,7 +6,7 @@ import {
   erÅrsakEnsligBesvart,
 } from '../../../../helpers/steg/omdeg';
 import Medlemskap from '../../../felles/steg/1-omdeg/medlemskap/Medlemskap';
-import Personopplysninger from '../../../felles/steg/1-omdeg/personopplysninger/Personopplysninger';
+import { Personopplysninger } from '../../../felles/steg/1-omdeg/personopplysninger/Personopplysninger';
 import Sivilstatus from '../../../felles/steg/1-omdeg/sivilstatus/Sivilstatus';
 import { Side, NavigasjonState } from '../../../../components/side/Side';
 import { kommerFraOppsummeringen } from '../../../../utils/locationState';

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import JaNeiSpørsmål from '../../../../../components/spørsmål/JaNeiSpørsmål';
-import SøkerBorIkkePåAdresse from './SøkerBorIkkePåAdresse';
+import { SøkerBorIkkePåAdresse } from './SøkerBorIkkePåAdresse';
 import { borDuPåDenneAdressen, harMeldtAdresseendringSpørsmål } from './PersonopplysningerConfig';
 import { hentBooleanFraValgtSvar } from '../../../../../utils/spørsmålogsvar';
 import { ISpørsmål, ISvar } from '../../../../../models/felles/spørsmålogsvar';

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -9,7 +9,7 @@ import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
 import AlertStripeDokumentasjon from '../../../../../components/AlertstripeDokumentasjon';
 import { hentTekst } from '../../../../../utils/teksthåndtering';
 import { PersonopplysningerVisning } from './PersonopplysningerVisning';
-import { Alert, VStack } from '@navikt/ds-react';
+import { VStack } from '@navikt/ds-react';
 import { useOmDeg } from '../OmDegContext';
 
 const Personopplysninger: React.FC = () => {
@@ -51,9 +51,6 @@ const Personopplysninger: React.FC = () => {
 
   return (
     <VStack gap={'8'}>
-      <Alert variant="info" inline={true}>
-        {hentTekst('personopplysninger.alert.infohentet', intl)}
-      </Alert>
       <PersonopplysningerVisning
         personIdent={søker.fnr}
         statsborgerskap={søker.statsborgerskap}

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -12,7 +12,7 @@ import { PersonopplysningerVisning } from './PersonopplysningerVisning';
 import { VStack } from '@navikt/ds-react';
 import { useOmDeg } from '../OmDegContext';
 
-const Personopplysninger: React.FC = () => {
+export const Personopplysninger: React.FC = () => {
   const intl = useLokalIntlContext();
   const {
     søknad,
@@ -93,5 +93,3 @@ const Personopplysninger: React.FC = () => {
     </VStack>
   );
 };
-
-export default Personopplysninger;

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -47,6 +47,8 @@ const Personopplysninger: React.FC = () => {
     settDokumentasjonsbehov(spørsmål, valgtSvar);
   };
 
+  const visAdresseSpørsmål = !søker?.erStrengtFortrolig;
+
   return (
     <VStack gap={'8'}>
       <Alert variant="info" inline={true}>
@@ -58,7 +60,8 @@ const Personopplysninger: React.FC = () => {
         sivilstand={søker.sivilstand}
         adresse={søker.adresse}
       />
-      {!søker?.erStrengtFortrolig && (
+
+      {visAdresseSpørsmål && (
         <>
           <KomponentGruppe aria-live="polite">
             <JaNeiSpørsmål

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -48,6 +48,9 @@ const Personopplysninger: React.FC = () => {
   };
 
   const visAdresseSpørsmål = !søker?.erStrengtFortrolig;
+  const visMeldtAdresseEndringSpørsmål = søkerBorPåRegistrertAdresse?.verdi === false;
+  const visMeldtAdresseEndringAlert = adresseopplysninger?.harMeldtAdresseendring?.verdi === true;
+  const visSøkerBorIkkePåAdresse = adresseopplysninger?.harMeldtAdresseendring?.verdi === false;
 
   return (
     <VStack gap={'8'}>
@@ -68,21 +71,21 @@ const Personopplysninger: React.FC = () => {
             />
           </KomponentGruppe>
 
-          {søkerBorPåRegistrertAdresse?.verdi === false && (
+          {visMeldtAdresseEndringSpørsmål && (
             <KomponentGruppe>
               <JaNeiSpørsmål
                 spørsmål={harMeldtAdresseendringSpørsmål(intl)}
                 valgtSvar={adresseopplysninger?.harMeldtAdresseendring?.verdi}
                 onChange={settMeldtAdresseendring}
               />
-              {adresseopplysninger?.harMeldtAdresseendring?.verdi === true && (
+
+              {visMeldtAdresseEndringAlert && (
                 <AlertStripeDokumentasjon>
                   {hentTekst('personopplysninger.alert.meldtAdresseendring', intl)}
                 </AlertStripeDokumentasjon>
               )}
-              {adresseopplysninger?.harMeldtAdresseendring?.verdi === false && (
-                <SøkerBorIkkePåAdresse stønadstype={stønadstype} />
-              )}
+
+              {visSøkerBorIkkePåAdresse && <SøkerBorIkkePåAdresse stønadstype={stønadstype} />}
             </KomponentGruppe>
           )}
         </>

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import JaNeiSpørsmål from '../../../../../components/spørsmål/JaNeiSpørsmål';
-import KomponentGruppe from '../../../../../components/gruppe/KomponentGruppe';
 import SøkerBorIkkePåAdresse from './SøkerBorIkkePåAdresse';
 import { borDuPåDenneAdressen, harMeldtAdresseendringSpørsmål } from './PersonopplysningerConfig';
 import { hentBooleanFraValgtSvar } from '../../../../../utils/spørsmålogsvar';
@@ -62,33 +61,29 @@ export const Personopplysninger: React.FC = () => {
       />
 
       {visAdresseSpørsmål && (
-        <>
-          <KomponentGruppe aria-live="polite">
-            <JaNeiSpørsmål
-              spørsmål={borDuPåDenneAdressen(intl)}
-              valgtSvar={søkerBorPåRegistrertAdresse?.verdi}
-              onChange={settSøkerBorPåRegistrertAdr}
-            />
-          </KomponentGruppe>
+        <VStack gap={'8'}>
+          <JaNeiSpørsmål
+            spørsmål={borDuPåDenneAdressen(intl)}
+            valgtSvar={søkerBorPåRegistrertAdresse?.verdi}
+            onChange={settSøkerBorPåRegistrertAdr}
+          />
 
           {visMeldtAdresseEndringSpørsmål && (
-            <KomponentGruppe>
-              <JaNeiSpørsmål
-                spørsmål={harMeldtAdresseendringSpørsmål(intl)}
-                valgtSvar={adresseopplysninger?.harMeldtAdresseendring?.verdi}
-                onChange={settMeldtAdresseendring}
-              />
-
-              {visMeldtAdresseEndringAlert && (
-                <AlertStripeDokumentasjon>
-                  {hentTekst('personopplysninger.alert.meldtAdresseendring', intl)}
-                </AlertStripeDokumentasjon>
-              )}
-
-              {visSøkerBorIkkePåAdresse && <SøkerBorIkkePåAdresse stønadstype={stønadstype} />}
-            </KomponentGruppe>
+            <JaNeiSpørsmål
+              spørsmål={harMeldtAdresseendringSpørsmål(intl)}
+              valgtSvar={adresseopplysninger?.harMeldtAdresseendring?.verdi}
+              onChange={settMeldtAdresseendring}
+            />
           )}
-        </>
+
+          {visMeldtAdresseEndringAlert && (
+            <AlertStripeDokumentasjon>
+              {hentTekst('personopplysninger.alert.meldtAdresseendring', intl)}
+            </AlertStripeDokumentasjon>
+          )}
+
+          {visSøkerBorIkkePåAdresse && <SøkerBorIkkePåAdresse stønadstype={stønadstype} />}
+        </VStack>
       )}
     </VStack>
   );

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/Personopplysninger.tsx
@@ -5,10 +5,9 @@ import { borDuPåDenneAdressen, harMeldtAdresseendringSpørsmål } from './Perso
 import { hentBooleanFraValgtSvar } from '../../../../../utils/spørsmålogsvar';
 import { ISpørsmål, ISvar } from '../../../../../models/felles/spørsmålogsvar';
 import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
-import AlertStripeDokumentasjon from '../../../../../components/AlertstripeDokumentasjon';
 import { hentTekst } from '../../../../../utils/teksthåndtering';
 import { PersonopplysningerVisning } from './PersonopplysningerVisning';
-import { VStack } from '@navikt/ds-react';
+import { Alert, VStack } from '@navikt/ds-react';
 import { useOmDeg } from '../OmDegContext';
 
 export const Personopplysninger: React.FC = () => {
@@ -77,9 +76,9 @@ export const Personopplysninger: React.FC = () => {
           )}
 
           {visMeldtAdresseEndringAlert && (
-            <AlertStripeDokumentasjon>
+            <Alert variant={'warning'} size={'small'} inline>
               {hentTekst('personopplysninger.alert.meldtAdresseendring', intl)}
-            </AlertStripeDokumentasjon>
+            </Alert>
           )}
 
           {visSøkerBorIkkePåAdresse && <SøkerBorIkkePåAdresse stønadstype={stønadstype} />}

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/PersonopplysningerVisning.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/PersonopplysningerVisning.tsx
@@ -24,7 +24,7 @@ export const PersonopplysningerVisning: React.FC<Props> = ({
 
   return (
     <VStack gap={'4'}>
-      <Alert variant="info" inline={true}>
+      <Alert variant="info" inline>
         {hentTekst('personopplysninger.alert.infohentet', intl)}
       </Alert>
 

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/PersonopplysningerVisning.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/PersonopplysningerVisning.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BodyShort, Heading, VStack } from '@navikt/ds-react';
+import { Alert, BodyShort, Heading, VStack } from '@navikt/ds-react';
 import { hentTekst } from '../../../../../utils/teksthåndtering';
 import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
 import { Adresse } from '../../../../../models/søknad/person';
@@ -24,24 +24,31 @@ export const PersonopplysningerVisning: React.FC<Props> = ({
 
   return (
     <VStack gap={'4'}>
+      <Alert variant="info" inline={true}>
+        {hentTekst('personopplysninger.alert.infohentet', intl)}
+      </Alert>
+
       <VStack align={'start'}>
         <Heading size="xsmall">{hentTekst('person.ident.visning', intl)}</Heading>
         <BodyShort size="medium" weight="regular">
           {personIdent}
         </BodyShort>
       </VStack>
+
       <VStack align={'start'}>
         <Heading size="xsmall">{hentTekst('person.statsborgerskap', intl)}</Heading>
         <BodyShort size="medium" weight="regular">
           {statsborgerskap}
         </BodyShort>
       </VStack>
+
       <VStack align={'start'}>
         <Heading size="xsmall">{hentTekst('sivilstatus.tittel', intl)}</Heading>
         <BodyShort size="medium" weight="regular">
           {formatertSivilstand}
         </BodyShort>
       </VStack>
+
       <VStack align={'start'}>
         <Heading size="xsmall">{hentTekst('person.adresse', intl)}</Heading>
         <BodyShort size="medium" weight="regular">

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/PersonopplysningerVisning.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/PersonopplysningerVisning.tsx
@@ -28,28 +28,28 @@ export const PersonopplysningerVisning: React.FC<Props> = ({
         {hentTekst('personopplysninger.alert.infohentet', intl)}
       </Alert>
 
-      <VStack align={'start'}>
+      <VStack>
         <Heading size="xsmall">{hentTekst('person.ident.visning', intl)}</Heading>
         <BodyShort size="medium" weight="regular">
           {personIdent}
         </BodyShort>
       </VStack>
 
-      <VStack align={'start'}>
+      <VStack>
         <Heading size="xsmall">{hentTekst('person.statsborgerskap', intl)}</Heading>
         <BodyShort size="medium" weight="regular">
           {statsborgerskap}
         </BodyShort>
       </VStack>
 
-      <VStack align={'start'}>
+      <VStack>
         <Heading size="xsmall">{hentTekst('sivilstatus.tittel', intl)}</Heading>
         <BodyShort size="medium" weight="regular">
           {formatertSivilstand}
         </BodyShort>
       </VStack>
 
-      <VStack align={'start'}>
+      <VStack>
         <Heading size="xsmall">{hentTekst('person.adresse', intl)}</Heading>
         <BodyShort size="medium" weight="regular">
           {adresse.adresse}

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/PersonopplysningerVisning.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/PersonopplysningerVisning.tsx
@@ -21,6 +21,7 @@ export const PersonopplysningerVisning: React.FC<Props> = ({
   const intl = useLokalIntlContext();
 
   const formatertSivilstand = utledFormatertSivilstand(sivilstand, intl);
+  const visAdresse = adresse.adresse.trim() !== '';
 
   return (
     <VStack gap={'4'}>
@@ -49,15 +50,17 @@ export const PersonopplysningerVisning: React.FC<Props> = ({
         </BodyShort>
       </VStack>
 
-      <VStack>
-        <Heading size="xsmall">{hentTekst('person.adresse', intl)}</Heading>
-        <BodyShort size="medium" weight="regular">
-          {adresse.adresse}
-        </BodyShort>
-        <BodyShort size="medium" weight="regular">
-          {adresse.poststed ? `${adresse.postnummer} - ${adresse.poststed}` : adresse.postnummer}
-        </BodyShort>
-      </VStack>
+      {visAdresse && (
+        <VStack>
+          <Heading size="xsmall">{hentTekst('person.adresse', intl)}</Heading>
+          <BodyShort size="medium" weight="regular">
+            {adresse.adresse}
+          </BodyShort>
+          <BodyShort size="medium" weight="regular">
+            {adresse.poststed ? `${adresse.postnummer} - ${adresse.poststed}` : adresse.postnummer}
+          </BodyShort>
+        </VStack>
+      )}
     </VStack>
   );
 };

--- a/src/søknader/felles/steg/1-omdeg/personopplysninger/SøkerBorIkkePåAdresse.tsx
+++ b/src/søknader/felles/steg/1-omdeg/personopplysninger/SøkerBorIkkePåAdresse.tsx
@@ -1,8 +1,6 @@
 import { FC } from 'react';
-import KomponentGruppe from '../../../../../components/gruppe/KomponentGruppe';
-import FeltGruppe from '../../../../../components/gruppe/FeltGruppe';
 import { Stønadstype } from '../../../../../models/søknad/stønadstyper';
-import { Alert, BodyShort, Label } from '@navikt/ds-react';
+import { Alert, BodyShort, Heading, VStack } from '@navikt/ds-react';
 import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
 import {
   hentHTMLTekst,
@@ -23,31 +21,23 @@ const lenkerPDFSøknad = {
     'https://www.nav.no/soknader/nb/person/familie/enslig-mor-eller-far/NAV%2015-00.04/dokumentinnsending',
 };
 
-const SøkerBorIkkePåAdresse: FC<Props> = ({ stønadstype }) => {
+export const SøkerBorIkkePåAdresse: FC<Props> = ({ stønadstype }) => {
   const intl = useLokalIntlContext();
+
   return (
-    <>
-      <KomponentGruppe>
-        <Alert size="small" variant="warning" inline>
-          {hentHTMLTekst('personopplysninger.alert.riktigAdresse', intl)}
-        </Alert>
-      </KomponentGruppe>
-      <KomponentGruppe>
-        <FeltGruppe>
-          <Label as="p">{hentTekst('personopplysninger.info.endreAdresse', intl)}</Label>
-        </FeltGruppe>
-        <FeltGruppe>
-          <BodyShort>
-            {hentHTMLTekstMedEnVariabel(
-              `personopplysninger.lenke.pdfskjema`,
-              intl,
-              lenkerPDFSøknad[stønadstype]
-            )}
-          </BodyShort>
-        </FeltGruppe>
-      </KomponentGruppe>
-    </>
+    <VStack gap={'8'}>
+      <Alert size="small" variant="warning" inline>
+        {hentHTMLTekst('personopplysninger.alert.riktigAdresse', intl)}
+      </Alert>
+
+      <Heading size={'xsmall'}>{hentTekst('personopplysninger.info.endreAdresse', intl)}</Heading>
+      <BodyShort>
+        {hentHTMLTekstMedEnVariabel(
+          `personopplysninger.lenke.pdfskjema`,
+          intl,
+          lenkerPDFSøknad[stønadstype]
+        )}
+      </BodyShort>
+    </VStack>
   );
 };
-
-export default SøkerBorIkkePåAdresse;


### PR DESCRIPTION
# Personopplysninger - fjern komponent og feltgruppe, legge til visning kondisjonal for spørsmål.

### Hvorfor er denne endringen nødvendig? ✨ 

Prøver å introdusere større endringer stykkevis. Derfor prøver denne PRen å fjerne feltgruppe og komponent gruppe og heller bruke native `VStack` og `Alert`. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25952).

### Verdt å nevne

* Har testet i preprod ved å trykke rundt
* Har testet med person som har adresse beskyttelse - dette gjøres fordi jeg gjemmer adresse heading om adressen er tom.