### PR TITLE
Fikser bug som lot bruker gå videre uten oppholdsland verdi

### DIFF
--- a/src/helpers/steg/omdeg.ts
+++ b/src/helpers/steg/omdeg.ts
@@ -87,7 +87,18 @@ export const erPeriodeDatoerValgt = (periode: IPeriode) => {
 };
 
 const erMedlemskapSpørsmålBesvart = (medlemskap: IMedlemskap): boolean => {
-  const { søkerBosattINorgeSisteTreÅr, perioderBoddIUtlandet } = medlemskap;
+  const {
+    søkerBosattINorgeSisteTreÅr,
+    perioderBoddIUtlandet,
+    søkerOppholderSegINorge,
+    oppholdsland,
+  } = medlemskap;
+
+  if (søkerOppholderSegINorge?.verdi === false) {
+    if (!oppholdsland?.verdi || stringErNullEllerTom(oppholdsland.verdi)) {
+      return false;
+    }
+  }
 
   if (perioderBoddIUtlandet !== null) {
     const finnesUtenlandsperiodeUtenBegrunnelseEllerDato = perioderBoddIUtlandet?.some(
@@ -100,6 +111,7 @@ const erMedlemskapSpørsmålBesvart = (medlemskap: IMedlemskap): boolean => {
           erEøsLand,
           adresseEøsLand,
         } = utenlandsopphold;
+
         const manglendeBegrunnelse = stringErNullEllerTom(begrunnelse.verdi);
         const manglerPeriode =
           stringErNullEllerTom(periode.fra.verdi) || stringErNullEllerTom(periode.til.verdi);
@@ -115,12 +127,8 @@ const erMedlemskapSpørsmålBesvart = (medlemskap: IMedlemskap): boolean => {
     );
 
     return søkerBosattINorgeSisteTreÅr?.verdi === false
-      ? finnesUtenlandsperiodeUtenBegrunnelseEllerDato
-        ? false
-        : true
-      : søkerBosattINorgeSisteTreÅr?.verdi
-        ? true
-        : false;
+      ? !finnesUtenlandsperiodeUtenBegrunnelseEllerDato
+      : !!søkerBosattINorgeSisteTreÅr?.verdi;
   } else return false;
 };
 


### PR DESCRIPTION
# Fikser bug som lot bruker gå videre uten oppholdsland verdi

### Hvorfor er denne endringen nødvendig? ✨ 

Under testing fant man en bug der bruker kunne gå videre i medlemskap seksjonen av om deg steget. Dette skjedde når:

Bruker svarer ja på "Oppholder du og barnet/barna dere i Norge?" og ja på "Har du oppholdt deg i Norge de siste 5 årene?" for å så endre til nei på "Oppholder du og barnet/barna dere i Norge?". Bruker fikk muligheten til å trykke på neste og gå videre til neste steg uten å velge verdi for oppholdsland.


<table>
  <tr>
    <th style="text-align:center">Før</th>
    <th style="text-align:center">Etter</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/8f8617cf-78de-4553-8f91-1f35ba10993c" alt="Før" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/2297ad71-0e6f-478e-b1ad-561a4b69b58f" alt="Etter" width="400"/></td>
  </tr>

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-26005).

### Verdt å nevne

Har kun testet i preprod