### PR TITLE
PeriodeDatovelger bruker nå native Aksel

### DIFF
--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -49,7 +49,7 @@ interface Props {
   onValidate?: (isValid: boolean) => void;
 }
 
-const PeriodeDatovelgere: FC<Props> = ({
+export const PeriodeDatovelgere: FC<Props> = ({
   className,
   periode,
   hjelpetekst,
@@ -141,5 +141,3 @@ const PeriodeDatovelgere: FC<Props> = ({
     </KomponentGruppe>
   );
 };
-
-export default PeriodeDatovelgere;

--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -4,8 +4,6 @@ import { EPeriode, IPeriode } from '../../models/felles/periode';
 import { IHjelpetekst } from '../../models/felles/hjelpetekst';
 import LesMerTekst from '../LesMerTekst';
 import styled from 'styled-components';
-import FeltGruppe from '../gruppe/FeltGruppe';
-import KomponentGruppe from '../gruppe/KomponentGruppe';
 import {
   erDatoerLike,
   erDatoInnenforBegrensing,
@@ -13,7 +11,7 @@ import {
   hentStartOgSluttDato,
 } from '../../utils/gyldigeDatoerUtils';
 import { erGyldigDato } from '../../utils/dato';
-import { Label } from '@navikt/ds-react';
+import { Heading, HStack, Label, VStack } from '@navikt/ds-react';
 import { Datovelger } from './Datovelger';
 import { GyldigeDatoer } from './GyldigeDatoer';
 
@@ -110,17 +108,18 @@ export const PeriodeDatovelgere: FC<Props> = ({
   };
 
   return (
-    <KomponentGruppe className={className}>
-      <FeltGruppe>
-        <Label as="p">{tekst}</Label>
+    <VStack gap={'6'}>
+      <VStack>
+        <Heading size={'xsmall'}>{tekst}</Heading>
         {hjelpetekst && (
           <LesMerTekst
             åpneTekstid={hjelpetekst.headerTekstid}
             innholdTekstid={hjelpetekst.innholdTekstid}
           />
         )}
-      </FeltGruppe>
-      <PeriodeGruppe className="periodegruppe" aria-live="polite">
+      </VStack>
+
+      <HStack gap={'6'}>
         <Datovelger
           settDato={(e) => settPeriode(EPeriode.fra, e)}
           valgtDato={periode.fra.verdi}
@@ -134,10 +133,11 @@ export const PeriodeDatovelgere: FC<Props> = ({
           tekstid={tomTekstid ? tomTekstid : 'periode.til'}
           gyldigeDatoer={gyldigeDatoer}
         />
-        {feilmelding && feilmelding !== '' && (
-          <Feilmelding className={'feilmelding'} tekstid={feilmelding} />
-        )}
-      </PeriodeGruppe>
-    </KomponentGruppe>
+      </HStack>
+
+      {feilmelding && feilmelding !== '' && (
+        <Feilmelding className={'feilmelding'} tekstid={feilmelding} />
+      )}
+    </VStack>
   );
 };

--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -1,5 +1,4 @@
 import { FC, useEffect, useState } from 'react';
-import Feilmelding from '../feil/Feilmelding';
 import { EPeriode, IPeriode } from '../../models/felles/periode';
 import { IHjelpetekst } from '../../models/felles/hjelpetekst';
 import LesMerTekst from '../LesMerTekst';

--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -3,7 +3,6 @@ import Feilmelding from '../feil/Feilmelding';
 import { EPeriode, IPeriode } from '../../models/felles/periode';
 import { IHjelpetekst } from '../../models/felles/hjelpetekst';
 import LesMerTekst from '../LesMerTekst';
-import styled from 'styled-components';
 import {
   erDatoerLike,
   erDatoInnenforBegrensing,
@@ -11,29 +10,9 @@ import {
   hentStartOgSluttDato,
 } from '../../utils/gyldigeDatoerUtils';
 import { erGyldigDato } from '../../utils/dato';
-import { Heading, HStack, Label, VStack } from '@navikt/ds-react';
+import { Heading, HStack, VStack } from '@navikt/ds-react';
 import { Datovelger } from './Datovelger';
 import { GyldigeDatoer } from './GyldigeDatoer';
-
-const PeriodeGruppe = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, min-content);
-  grid-gap: 2rem;
-
-  .feilmelding {
-    grid-column: 1/3;
-  }
-
-  @media (max-width: 420px) {
-    grid-template-columns: 1fr;
-    grid-template-rows: repeat(3, 1fr);
-    grid-gap: 2rem;
-
-    .feilmelding {
-      grid-column: 1/2;
-    }
-  }
-`;
 
 interface Props {
   className?: string;
@@ -48,7 +27,6 @@ interface Props {
 }
 
 export const PeriodeDatovelgere: FC<Props> = ({
-  className,
   periode,
   hjelpetekst,
   settDato,

--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -88,13 +88,14 @@ export const PeriodeDatovelgere: FC<Props> = ({
     settDato(objektnøkkel, dato);
   };
 
+  const visLesMer = hjelpetekst;
   const visDatoFeilmelding = feilmelding && feilmelding !== '';
 
   return (
     <VStack gap={'6'}>
       <VStack>
         <Heading size={'xsmall'}>{tekst}</Heading>
-        {hjelpetekst && (
+        {visLesMer && (
           <LesMerTekst
             åpneTekstid={hjelpetekst.headerTekstid}
             innholdTekstid={hjelpetekst.innholdTekstid}

--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -10,9 +10,11 @@ import {
   hentStartOgSluttDato,
 } from '../../utils/gyldigeDatoerUtils';
 import { erGyldigDato } from '../../utils/dato';
-import { Heading, HStack, VStack } from '@navikt/ds-react';
+import { Alert, Heading, HStack, VStack } from '@navikt/ds-react';
 import { Datovelger } from './Datovelger';
 import { GyldigeDatoer } from './GyldigeDatoer';
+import { hentTekst } from '../../utils/teksthåndtering';
+import { useLokalIntlContext } from '../../context/LokalIntlContext';
 
 interface Props {
   className?: string;
@@ -36,6 +38,8 @@ export const PeriodeDatovelgere: FC<Props> = ({
   gyldigeDatoer,
   onValidate,
 }) => {
+  const intl = useLokalIntlContext();
+
   const [feilmelding, settFeilmelding] = useState<string>('');
 
   const sammenlignDatoerOgHentFeilmelding = (
@@ -114,7 +118,9 @@ export const PeriodeDatovelgere: FC<Props> = ({
       </HStack>
 
       {feilmelding && feilmelding !== '' && (
-        <Feilmelding className={'feilmelding'} tekstid={feilmelding} />
+        <Alert variant={'error'} size={'small'}>
+          {hentTekst(feilmelding, intl)}
+        </Alert>
       )}
     </VStack>
   );

--- a/src/components/dato/PeriodeDatovelger.tsx
+++ b/src/components/dato/PeriodeDatovelger.tsx
@@ -89,6 +89,8 @@ export const PeriodeDatovelgere: FC<Props> = ({
     settDato(objektnøkkel, dato);
   };
 
+  const visDatoFeilmelding = feilmelding && feilmelding !== '';
+
   return (
     <VStack gap={'6'}>
       <VStack>
@@ -117,7 +119,7 @@ export const PeriodeDatovelgere: FC<Props> = ({
         />
       </HStack>
 
-      {feilmelding && feilmelding !== '' && (
+      {visDatoFeilmelding && (
         <Alert variant={'error'} size={'small'}>
           {hentTekst(feilmelding, intl)}
         </Alert>

--- a/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassSpørsmål.tsx
+++ b/src/søknader/barnetilsyn/steg/6-barnepass/BarnepassSpørsmål.tsx
@@ -3,7 +3,7 @@ import SeksjonGruppe from '../../../../components/gruppe/SeksjonGruppe';
 import { IBarn } from '../../../../models/steg/barn';
 import KomponentGruppe from '../../../../components/gruppe/KomponentGruppe';
 import MultiSvarSpørsmålMedNavn from '../../../../components/spørsmål/MultiSvarSpørsmålMedNavn';
-import PeriodeDatovelgere from '../../../../components/dato/PeriodeDatovelger';
+import { PeriodeDatovelgere } from '../../../../components/dato/PeriodeDatovelger';
 import { SlettKnapp } from '../../../../components/knapper/SlettKnapp';
 import { hentBarnNavnEllerBarnet } from '../../../../utils/barn';
 import { hentTittelMedNr } from '../../../../language/utils';

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { SlettKnapp } from '../../../../../components/knapper/SlettKnapp';
 import { hentTittelMedNr } from '../../../../../language/utils';
-import PeriodeDatovelgere from '../../../../../components/dato/PeriodeDatovelger';
+import { PeriodeDatovelgere } from '../../../../../components/dato/PeriodeDatovelger';
 import { hentTekst, hentTekstMedEnVariabel } from '../../../../../utils/teksthåndtering';
 import { ILandMedKode, IUtenlandsopphold } from '../../../../../models/steg/omDeg/medlemskap';
 import { erPeriodeDatoerValgt } from '../../../../../helpers/steg/omdeg';

--- a/src/søknader/felles/steg/5-aktivitet/utdanning/NårSkalDuElevEllerStudent.tsx
+++ b/src/søknader/felles/steg/5-aktivitet/utdanning/NårSkalDuElevEllerStudent.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { UnderUtdanning } from '../../../../../models/steg/aktivitet/utdanning';
-import PeriodeDatovelgere from '../../../../../components/dato/PeriodeDatovelger';
+import { PeriodeDatovelgere } from '../../../../../components/dato/PeriodeDatovelger';
 import { tomPeriode } from '../../../../../helpers/tommeSøknadsfelter';
 import { hentTekst } from '../../../../../utils/teksthåndtering';
 import { EPeriode } from '../../../../../models/felles/periode';


### PR DESCRIPTION
# PeriodeDatovelger bruker nå native Aksel

### Hvorfor er denne endringen nødvendig? ✨ 

Jobber med å utbedre større endringer, ønsker derfor å fjerne komponent gruppe og felt gruppe fra steder der dette er brukt. PeriodeDatovelger bruker nå native Aksel, samt fjerner styled div og komponent/feltgruppe. Vi bruker nå også en direkte alert på feilmelding.

<table>
  <tr>
    <th style="text-align:center">Før</th>
    <th style="text-align:center">Etter</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/6e9f2b6a-1b59-42ee-bcd8-5c3837d7911f" alt="Før" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/374f1e77-35d9-4514-941f-364a5cfddda4" alt="Etter" width="400"/></td>
  </tr>

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-26030).

### Verdt å nevne

* Har kun testet i pre-prod.
* Har testet med mobil og passet på at ting legger seg riktig ved mindre skjermstørrelse.
* Har testet med VoiceOver.
* Har sjekket stedene der komponenten blir tatt i bruk for å forsikre meg om at det ser riktig ut. 