### PR TITLE
Utenlandsopphold bruker nå native Aksel og visningkondisjonal

### DIFF
--- a/src/components/EøsIdent.tsx
+++ b/src/components/EøsIdent.tsx
@@ -12,7 +12,7 @@ interface Props {
   settUtenlandsopphold: (utenlandsopphold: IUtenlandsopphold) => void;
 }
 
-const EøsIdent: React.FC<Props> = ({
+export const EøsIdent: React.FC<Props> = ({
   halvåpenTekstid,
   åpneTekstid,
   utenlandsopphold,
@@ -83,5 +83,3 @@ const EøsIdent: React.FC<Props> = ({
     </div>
   );
 };
-
-export default EøsIdent;

--- a/src/components/EøsIdent.tsx
+++ b/src/components/EøsIdent.tsx
@@ -53,10 +53,10 @@ export const EøsIdent: React.FC<Props> = ({
 
   return (
     <VStack gap={'6'}>
-      <Label>{utenlandskIDNummerTekst}</Label>
-      <ReadMore size={'small'} header={halvåpenTekstid}>
-        {åpneTekstid}
-      </ReadMore>
+      <VStack>
+        <Label>{utenlandskIDNummerTekst}</Label>
+        <ReadMore header={halvåpenTekstid}>{åpneTekstid}</ReadMore>
+      </VStack>
 
       <TextField
         key={'navn'}

--- a/src/components/EøsIdent.tsx
+++ b/src/components/EøsIdent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Checkbox, Label, ReadMore } from '@navikt/ds-react';
-import { TextFieldMedBredde } from './TextFieldMedBredde';
+import { Checkbox, Label, ReadMore, TextField, VStack } from '@navikt/ds-react';
 import { hentTekstMedEnVariabel } from '../utils/teksthåndtering';
 import { useLokalIntlContext } from '../context/LokalIntlContext';
 import { IUtenlandsopphold } from '../models/steg/omDeg/medlemskap';
@@ -53,23 +52,23 @@ export const EøsIdent: React.FC<Props> = ({
   };
 
   return (
-    <div>
+    <VStack gap={'6'}>
       <Label>{utenlandskIDNummerTekst}</Label>
       <ReadMore size={'small'} header={halvåpenTekstid}>
         {åpneTekstid}
       </ReadMore>
-      <TextFieldMedBredde
-        className={'inputfelt-tekst'}
+
+      <TextField
         key={'navn'}
         label={utenlandskIDNummerTekst}
         hideLabel={true}
         type="text"
-        bredde={'L'}
         onChange={(e) => settUtenlandskPersonId(e)}
         value={utenlandsopphold.personidentEøsLand?.verdi}
         disabled={utenlandsopphold.kanIkkeOppgiPersonident}
         maxLength={32}
       />
+
       <Checkbox
         checked={utenlandsopphold.kanIkkeOppgiPersonident}
         onChange={() => toggleHarUtenlandskPersonId(!utenlandsopphold.kanIkkeOppgiPersonident)}
@@ -80,6 +79,6 @@ export const EøsIdent: React.FC<Props> = ({
           utenlandsopphold.land.verdi
         )}
       </Checkbox>
-    </div>
+    </VStack>
   );
 };

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.module.css
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.module.css
@@ -1,0 +1,3 @@
+.leggTilKnapp {
+    align-self: center;
+}

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.module.css
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.module.css
@@ -1,3 +1,0 @@
-.leggTilKnapp {
-    align-self: center;
-}

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from 'react';
-import Utenlandsopphold from './Utenlandsopphold';
+import { Utenlandsopphold } from './Utenlandsopphold';
 import { hentTekst } from '../../../../../utils/teksthåndtering';
 import { hentUid } from '../../../../../utils/autentiseringogvalidering/uuid';
 import { ILandMedKode, IUtenlandsopphold } from '../../../../../models/steg/omDeg/medlemskap';

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
@@ -8,7 +8,6 @@ import LeggTilKnapp from '../../../../../components/knapper/LeggTilKnapp';
 import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
 import { Heading, VStack } from '@navikt/ds-react';
 import { useOmDeg } from '../OmDegContext';
-import styles from './PeriodeBoddIUtlandet.module.css';
 
 export const PeriodeBoddIUtlandet: FC<{
   land: ILandMedKode[];
@@ -70,7 +69,7 @@ export const PeriodeBoddIUtlandet: FC<{
           <Heading size={'xsmall'}>
             {hentTekst('medlemskap.periodeBoddIUtlandet.flereutenlandsopphold', intl)}
           </Heading>
-          <div className={styles.leggTilKnapp}>
+          <div>
             <LeggTilKnapp onClick={leggTilUtenlandsperiode}>
               {hentTekst('medlemskap.periodeBoddIUtlandet.knapp', intl)}
             </LeggTilKnapp>

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/PeriodeBoddIUtlandet.tsx
@@ -8,6 +8,7 @@ import LeggTilKnapp from '../../../../../components/knapper/LeggTilKnapp';
 import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
 import { Heading, VStack } from '@navikt/ds-react';
 import { useOmDeg } from '../OmDegContext';
+import styles from './PeriodeBoddIUtlandet.module.css';
 
 export const PeriodeBoddIUtlandet: FC<{
   land: ILandMedKode[];
@@ -69,9 +70,11 @@ export const PeriodeBoddIUtlandet: FC<{
           <Heading size={'xsmall'}>
             {hentTekst('medlemskap.periodeBoddIUtlandet.flereutenlandsopphold', intl)}
           </Heading>
-          <LeggTilKnapp onClick={leggTilUtenlandsperiode}>
-            {hentTekst('medlemskap.periodeBoddIUtlandet.knapp', intl)}
-          </LeggTilKnapp>
+          <div className={styles.leggTilKnapp}>
+            <LeggTilKnapp onClick={leggTilUtenlandsperiode}>
+              {hentTekst('medlemskap.periodeBoddIUtlandet.knapp', intl)}
+            </LeggTilKnapp>
+          </div>
         </VStack>
       )}
     </VStack>

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -6,31 +6,15 @@ import { hentTekst, hentTekstMedEnVariabel } from '../../../../../utils/teksthå
 import { ILandMedKode, IUtenlandsopphold } from '../../../../../models/steg/omDeg/medlemskap';
 import { erPeriodeDatoerValgt } from '../../../../../helpers/steg/omdeg';
 import { EPeriode } from '../../../../../models/felles/periode';
-import styled from 'styled-components';
 import { erPeriodeGyldigOgInnenforBegrensning } from '../../../../../utils/gyldigeDatoerUtils';
 import { useLokalIntlContext } from '../../../../../context/LokalIntlContext';
-import { Heading, HStack, Textarea } from '@navikt/ds-react';
+import { Heading, HStack, Textarea, TextField, VStack } from '@navikt/ds-react';
 import SelectSpørsmål from '../../../../../components/spørsmål/SelectSpørsmål';
 import { ISpørsmål, ISvar } from '../../../../../models/felles/spørsmålogsvar';
 import { utenlandsoppholdLand } from './MedlemskapConfig';
-import { TextFieldMedBredde } from '../../../../../components/TextFieldMedBredde';
 import EøsIdent from '../../../../../components/EøsIdent';
 import { stringHarVerdiOgErIkkeTom } from '../../../../../utils/typer';
 import { GyldigeDatoer } from '../../../../../components/dato/GyldigeDatoer';
-
-const StyledTextarea = styled(Textarea)`
-  width: 100%;
-`;
-
-const StyledPeriodeDatovelgere = styled(PeriodeDatovelgere)`
-  padding-bottom: 0;
-`;
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-`;
 
 interface Props {
   perioderBoddIUtlandet: IUtenlandsopphold[];
@@ -47,8 +31,10 @@ export const Utenlandsopphold: FC<Props> = ({
   utenlandsopphold,
   land,
 }) => {
-  const { periode, begrunnelse, adresseEøsLand } = utenlandsopphold;
   const intl = useLokalIntlContext();
+
+  const { periode, begrunnelse, adresseEøsLand } = utenlandsopphold;
+
   const periodeTittel = hentTittelMedNr(
     perioderBoddIUtlandet!,
     oppholdsnr,
@@ -148,11 +134,12 @@ export const Utenlandsopphold: FC<Props> = ({
   const skalViseSlettKnapp = perioderBoddIUtlandet?.length > 1;
 
   return (
-    <Container aria-live="polite">
+    <VStack gap={'6'}>
       <HStack justify="space-between" align="center">
-        <Heading size="small" level="3" className={'tittel'}>
+        <Heading size="small" level="3">
           {periodeTittel}
         </Heading>
+
         {skalViseSlettKnapp && (
           <SlettKnapp
             onClick={() => fjernUtenlandsperiode()}
@@ -161,24 +148,25 @@ export const Utenlandsopphold: FC<Props> = ({
         )}
       </HStack>
 
-      <StyledPeriodeDatovelgere
-        className={'periodegruppe'}
-        settDato={settPeriode}
-        periode={utenlandsopphold.periode}
+      <PeriodeDatovelgere
         tekst={hentTekst('medlemskap.periodeBoddIUtlandet', intl)}
+        periode={utenlandsopphold.periode}
+        settDato={settPeriode}
         gyldigeDatoer={GyldigeDatoer.Tidligere}
       />
+
       <SelectSpørsmål
         spørsmål={landConfig}
         settSpørsmålOgSvar={settLand}
         valgtSvarId={perioderBoddIUtlandet[oppholdsnr].land?.svarid}
         skalLogges={false}
       />
+
       {erPeriodeDatoerValgt(utenlandsopphold.periode) &&
         erPeriodeGyldigOgInnenforBegrensning(utenlandsopphold.periode, GyldigeDatoer.Tidligere) &&
         // eslint-disable-next-line no-prototype-builtins
         utenlandsopphold.land?.hasOwnProperty('verdi') && (
-          <StyledTextarea
+          <Textarea
             label={begrunnelseTekst}
             placeholder={'...'}
             value={begrunnelse.verdi}
@@ -202,17 +190,16 @@ export const Utenlandsopphold: FC<Props> = ({
           }
         />
       )}
+
       {utenlandsopphold.land && skalViseAdresseTekstfelt(utenlandsopphold) && (
-        <TextFieldMedBredde
-          className={'inputfelt-tekst'}
+        <TextField
           key={'navn'}
           label={sisteAdresseTekst}
           type="text"
-          bredde={'L'}
           onChange={(e) => settFeltNavn(e, 'adresseEøsLand', sisteAdresseTekst)}
           value={adresseEøsLand?.verdi}
         />
       )}
-    </Container>
+    </VStack>
   );
 };

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -52,6 +52,7 @@ export const Utenlandsopphold: FC<Props> = ({
   );
 
   const landConfig = utenlandsoppholdLand(land);
+  const harValgUtenlandsOppholdLand = utenlandsopphold.land?.verdi !== undefined;
 
   const fjernUtenlandsperiode = () => {
     if (perioderBoddIUtlandet && perioderBoddIUtlandet.length > 1) {
@@ -135,8 +136,7 @@ export const Utenlandsopphold: FC<Props> = ({
   const visBegrunnelseTextArea =
     erPeriodeDatoerValgt(utenlandsopphold.periode) &&
     erPeriodeGyldigOgInnenforBegrensning(utenlandsopphold.periode, GyldigeDatoer.Tidligere) &&
-    // eslint-disable-next-line no-prototype-builtins
-    utenlandsopphold.land?.hasOwnProperty('verdi');
+    harValgUtenlandsOppholdLand;
   const visEøsIdent = utenlandsopphold.land && skalVisePersonidentTekstfelt(utenlandsopphold);
   const visSisteAdressTextField =
     utenlandsopphold.land && skalViseAdresseTekstfelt(utenlandsopphold);

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -131,7 +131,15 @@ export const Utenlandsopphold: FC<Props> = ({
     );
   };
 
-  const skalViseSlettKnapp = perioderBoddIUtlandet?.length > 1;
+  const visSlettKnapp = perioderBoddIUtlandet?.length > 1;
+  const visBegrunnelseTextArea =
+    erPeriodeDatoerValgt(utenlandsopphold.periode) &&
+    erPeriodeGyldigOgInnenforBegrensning(utenlandsopphold.periode, GyldigeDatoer.Tidligere) &&
+    // eslint-disable-next-line no-prototype-builtins
+    utenlandsopphold.land?.hasOwnProperty('verdi');
+  const visEøsIdent = utenlandsopphold.land && skalVisePersonidentTekstfelt(utenlandsopphold);
+  const visSisteAdressTextField =
+    utenlandsopphold.land && skalViseAdresseTekstfelt(utenlandsopphold);
 
   return (
     <VStack gap={'6'}>
@@ -140,7 +148,7 @@ export const Utenlandsopphold: FC<Props> = ({
           {periodeTittel}
         </Heading>
 
-        {skalViseSlettKnapp && (
+        {visSlettKnapp && (
           <SlettKnapp
             onClick={() => fjernUtenlandsperiode()}
             tekstid={'medlemskap.periodeBoddIUtlandet.slett'}
@@ -162,25 +170,22 @@ export const Utenlandsopphold: FC<Props> = ({
         skalLogges={false}
       />
 
-      {erPeriodeDatoerValgt(utenlandsopphold.periode) &&
-        erPeriodeGyldigOgInnenforBegrensning(utenlandsopphold.periode, GyldigeDatoer.Tidligere) &&
-        // eslint-disable-next-line no-prototype-builtins
-        utenlandsopphold.land?.hasOwnProperty('verdi') && (
-          <Textarea
-            label={begrunnelseTekst}
-            placeholder={'...'}
-            value={begrunnelse.verdi}
-            maxLength={1000}
-            autoComplete={'off'}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-              if (e.target.value.length <= 1000) {
-                settFeltNavn(e, 'begrunnelse', begrunnelseTekst);
-              }
-            }}
-          />
-        )}
+      {visBegrunnelseTextArea && (
+        <Textarea
+          label={begrunnelseTekst}
+          placeholder={'...'}
+          value={begrunnelse.verdi}
+          maxLength={1000}
+          autoComplete={'off'}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            if (e.target.value.length <= 1000) {
+              settFeltNavn(e, 'begrunnelse', begrunnelseTekst);
+            }
+          }}
+        />
+      )}
 
-      {utenlandsopphold.land && skalVisePersonidentTekstfelt(utenlandsopphold) && (
+      {visEøsIdent && (
         <EøsIdent
           halvåpenTekstid={hentTekst('medlemskap.hjelpetekst-åpne.begrunnelse', intl)}
           åpneTekstid={hentTekst('medlemskap.hjelpetekst-innhold.begrunnelse', intl)}
@@ -191,7 +196,7 @@ export const Utenlandsopphold: FC<Props> = ({
         />
       )}
 
-      {utenlandsopphold.land && skalViseAdresseTekstfelt(utenlandsopphold) && (
+      {visSisteAdressTextField && (
         <TextField
           key={'navn'}
           label={sisteAdresseTekst}

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -39,7 +39,8 @@ interface Props {
   oppholdsnr: number;
   land: ILandMedKode[];
 }
-const Utenlandsopphold: FC<Props> = ({
+
+export const Utenlandsopphold: FC<Props> = ({
   perioderBoddIUtlandet,
   settPeriodeBoddIUtlandet,
   oppholdsnr,
@@ -215,5 +216,3 @@ const Utenlandsopphold: FC<Props> = ({
     </Container>
   );
 };
-
-export default Utenlandsopphold;

--- a/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
+++ b/src/søknader/felles/steg/1-omdeg/medlemskap/Utenlandsopphold.tsx
@@ -12,7 +12,7 @@ import { Heading, HStack, Textarea, TextField, VStack } from '@navikt/ds-react';
 import SelectSpørsmål from '../../../../../components/spørsmål/SelectSpørsmål';
 import { ISpørsmål, ISvar } from '../../../../../models/felles/spørsmålogsvar';
 import { utenlandsoppholdLand } from './MedlemskapConfig';
-import EøsIdent from '../../../../../components/EøsIdent';
+import { EøsIdent } from '../../../../../components/EøsIdent';
 import { stringHarVerdiOgErIkkeTom } from '../../../../../utils/typer';
 import { GyldigeDatoer } from '../../../../../components/dato/GyldigeDatoer';
 


### PR DESCRIPTION
# Utenlandsopphold bruker nå native Aksel og visningkondisjonal

### Hvorfor er denne endringen nødvendig? ✨ 

Jobber med å utbedre større endringer, ønsker derfor å fjerne komponent gruppe og felt gruppe fra steder der dette er brukt. Utenlandsopphold bruker nå native Aksel, samt fjerner styled div og komponent/feltgruppe.

<table>
  <tr>
    <th style="text-align:center">Før</th>
    <th style="text-align:center">Etter</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/33775328-5655-45e4-99b0-d200d03442b7" alt="Før" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/5c140c03-aef9-4871-bf6d-a49d5482b80d" alt="Etter" width="400"/></td>
  </tr>

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-26031).

### Verdt å nevne

* Har kun testet i pre-prod.
* Har testet med mobil og passet på at ting legger seg riktig ved mindre skjermstørrelse.