### PR TITLE
Fikser fetchToggles warning fra ESLint

### DIFF
--- a/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
+++ b/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
@@ -31,17 +31,19 @@ const App = () => {
 
   autentiseringsInterceptor();
 
-  const fetchToggles = () => {
-    return hentToggles(settToggles).catch(() => {
-      settError(true);
-    });
-  };
-
   useEffect(() => {
     verifiserAtBrukerErAutentisert(settAutentisering);
-  }, [autentisert]);
+  }, []);
 
   useEffect(() => {
+    const fetchToggles = async () => {
+      try {
+        return await hentToggles(settToggles);
+      } catch {
+        settError(true);
+      }
+    };
+
     const fetchData = () => {
       const fetchPersonData = () => {
         hentPersonDataArbeidssoker()
@@ -64,7 +66,7 @@ const App = () => {
       settFetching(false);
     };
     fetchData();
-  }, []);
+  }, [settToggles]);
 
   if (!fetching && autentisert) {
     if (!error) {

--- a/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
+++ b/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
@@ -32,42 +32,31 @@ const App = () => {
   autentiseringsInterceptor();
 
   useEffect(() => {
-    const authPromise = verifiserAtBrukerErAutentisert(settAutentisering);
-
-    authPromise?.catch(() => {
-      settError(true);
-    });
-  }, []);
+    verifiserAtBrukerErAutentisert(settAutentisering);
+  }, [autentisert]);
 
   useEffect(() => {
-    const fetchToggles = async () => {
-      try {
-        return await hentToggles(settToggles);
-      } catch {
-        settError(true);
-      }
-    };
-
     const fetchData = () => {
-      const fetchPersonData = async () => {
-        try {
-          const response = await hentPersonDataArbeidssoker();
-          settIdent(response.ident);
-          settVisningsnavn(response.visningsnavn);
+      const fetchPersonData = () => {
+        hentPersonDataArbeidssoker()
+          .then((response) => {
+            settIdent(response.ident);
+            settVisningsnavn(response.visningsnavn);
+          })
+          .then(() => {
+            hentToggles(settToggles).catch(() => {
+              settError(true);
+            });
 
-          await fetchToggles();
-
-          settError(false);
-          settFeilmelding('');
-        } catch {
-          settError(true);
-          settFeilmelding('skjema.feilmelding.uthenting');
-        }
+            settError(false);
+            settFeilmelding('');
+          })
+          .catch(() => {
+            settError(true);
+            settFeilmelding('skjema.feilmelding.uthenting');
+          });
       };
-      fetchPersonData().catch(() => {
-        settError(true);
-        settFeilmelding('skjema.feilmelding.uthenting');
-      });
+      fetchPersonData();
       settFetching(false);
     };
     fetchData();

--- a/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
+++ b/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
@@ -32,7 +32,11 @@ const App = () => {
   autentiseringsInterceptor();
 
   useEffect(() => {
-    verifiserAtBrukerErAutentisert(settAutentisering);
+    const authPromise = verifiserAtBrukerErAutentisert(settAutentisering);
+
+    authPromise?.catch(() => {
+      settError(true);
+    });
   }, []);
 
   useEffect(() => {
@@ -45,24 +49,25 @@ const App = () => {
     };
 
     const fetchData = () => {
-      const fetchPersonData = () => {
-        hentPersonDataArbeidssoker()
-          .then((response) => {
-            settIdent(response.ident);
-            settVisningsnavn(response.visningsnavn);
-          })
-          .then(() => {
-            fetchToggles();
+      const fetchPersonData = async () => {
+        try {
+          const response = await hentPersonDataArbeidssoker();
+          settIdent(response.ident);
+          settVisningsnavn(response.visningsnavn);
 
-            settError(false);
-            settFeilmelding('');
-          })
-          .catch(() => {
-            settError(true);
-            settFeilmelding('skjema.feilmelding.uthenting');
-          });
+          await fetchToggles();
+
+          settError(false);
+          settFeilmelding('');
+        } catch {
+          settError(true);
+          settFeilmelding('skjema.feilmelding.uthenting');
+        }
       };
-      fetchPersonData();
+      fetchPersonData().catch(() => {
+        settError(true);
+        settFeilmelding('skjema.feilmelding.uthenting');
+      });
       settFetching(false);
     };
     fetchData();

--- a/src/utils/autentiseringogvalidering/autentisering.ts
+++ b/src/utils/autentiseringogvalidering/autentisering.ts
@@ -48,7 +48,7 @@ export const verifiserAtBrukerErAutentisert = (
   settAutentisering: (autentisering: boolean) => void
 ) => {
   if (loggInn()) {
-    return verifiserInnloggetApi().then((response) => {
+    verifiserInnloggetApi().then((response) => {
       if (response && 200 === response.status) {
         settAutentisering(true);
       }


### PR DESCRIPTION
# Fikser fetchToggles warning fra ESLint

### Hvorfor er denne endringen nødvendig? ✨ 

Forsøker å introdusere små endringer i håp om å gjøre søknadsdialogen litt enklere og bedre. Ved start mot pre-prod får vi en warning i konsollen der ESLint formidler at fetchToggles mangler et dependency array. IntelliJ formidler også at vi ikke tar i bruke promisene for metoder som `verifiserAtBrukerErAutentisert`. Prøver derfor å utbedre dette slik at det blir rikig i henhold til TS konvensjoner. 

Typisk warning vi får er:

```
WARNING in [eslint] 
/Users/Kristian.Kofoed/IdeaProjects/familie-ef-soknad-frontend/src/søknader/arbeidssøkerskjema/SkjemaApp.tsx
  67:6  warning  React Hook useEffect has a missing dependency: 'fetchToggles'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

✖ 1 problem (0 errors, 1 warning)
```

Denne endringen fjerner warnings siden implemenetasjonen er utbedret. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-26080).

### Verdt å nevne

* Har testet lokalt mot preprod
* Har deployet i dev og testet preprod
* Har ikke testet feature toggle, men virker som disse bare fungerer uansett der vi får 200 OK på `fetchToggles`